### PR TITLE
Fixe explain query with like statement

### DIFF
--- a/powa/query.py
+++ b/powa/query.py
@@ -239,7 +239,9 @@ class QueryExplains(ContentWidget):
                 query = format_jumbled_query(row['query'], vals['constants'])
                 plan = "N/A"
                 try:
-                    result = self.execute("EXPLAIN %s" % query,
+                    from sqlalchemy import text
+                    sqlQuery = text("EXPLAIN %s" % query)
+                    result = self.execute(sqlQuery,
                                           database=database)
                     plan = "\n".join(v[0] for v in result)
                 except:

--- a/powa/query.py
+++ b/powa/query.py
@@ -239,7 +239,6 @@ class QueryExplains(ContentWidget):
                 query = format_jumbled_query(row['query'], vals['constants'])
                 plan = "N/A"
                 try:
-                    from sqlalchemy import text
                     sqlQuery = text("EXPLAIN %s" % query)
                     result = self.execute(sqlQuery,
                                           database=database)


### PR DESCRIPTION
Hello Dalibo team
This pull request fixe "TypeError: 'dict' object does not support indexing" error by adding call text function from sqlalchemy.

This error occurs when the powa-web application explains a query with like statement '%'.