### PR TITLE
Fix wrong calculation of microseconds difference

### DIFF
--- a/powa/static/js/powa/utils/duration.js
+++ b/powa/static/js/powa/utils/duration.js
@@ -24,7 +24,7 @@ define(['moment'], function(moment){
     };
     moment.preciseDiff = function(d1, d2) {
         var m1 = moment(d1), m2 = moment(d2);
-        if (m1.isAfter(m2)) {
+        if (m1.isAfter(m2) || (m1.isSame(m2) && m1._i > m2._i)) {
             var tmp = m1;
             m1 = m2;
             m2 = tmp;
@@ -38,7 +38,7 @@ define(['moment'], function(moment){
         var msecDiff = m2.millisecond() - m1.millisecond();
         var microsecDiff = 0;
         if(typeof m1._i == "number" && typeof m2._i == "number"){
-            microsecDiff = Math.round((1000 * (m1._i - Math.floor(m1)) - 1000 * (m2._i - Math.floor(m2))))
+            microsecDiff = Math.round((1000 * (m2._i - Math.floor(m2)) - 1000 * (m1._i - Math.floor(m1))))
         } else {
             if (m1.isSame(m2)) {
                 return STRINGS.nodiff;


### PR DESCRIPTION
The isAfter function seems to only compare up to milliseconds so we have
to manually compare for more precision if m1 and m2 seem equal.

The calculation for microsecDiff was inverted.

Should fix dalibo/powa#88 .