### PR TITLE
Use grunt-sass instead of grunt-contrib-sass

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -83,7 +83,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-requirejs');
   grunt.loadNpmTasks('grunt-contrib-uglify');
-  grunt.loadNpmTasks('grunt-contrib-sass');
+  grunt.loadNpmTasks('grunt-sass');
 
   grunt.registerTask('default', ['bowerRequirejs', 'copy', 'sass']);
   grunt.registerTask('dist', ['bowerRequirejs', 'copy', 'requirejs', 'sass']);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "grunt-contrib-jshint": "0.10.0",
     "grunt-contrib-nodeunit": "0.4.1",
     "grunt-contrib-requirejs": "0.4.4",
-    "grunt-contrib-sass": "0.8.1",
+    "grunt-sass": "^2.0.0",
     "grunt-contrib-uglify": "0.5.0"
   }
 }

--- a/powa/static/css/powa-all.min.css
+++ b/powa/static/css/powa-all.min.css
@@ -96,6 +96,7 @@ img {
 .clearfix:before, .clearfix:after {
   content: " ";
   display: table; }
+
 .clearfix:after {
   clear: both; }
 
@@ -168,6 +169,7 @@ select {
 .columns +
 .columns:last-child {
   float: right; }
+
 .column + .column.end,
 .columns + .column.end, .column +
 .columns.end,
@@ -180,232 +182,177 @@ select {
     position: relative;
     left: 0;
     right: auto; }
-
   .small-pull-0 {
     position: relative;
     right: 0;
     left: auto; }
-
   .small-push-1 {
     position: relative;
-    left: 8.33333%;
+    left: 8.3333333333%;
     right: auto; }
-
   .small-pull-1 {
     position: relative;
-    right: 8.33333%;
+    right: 8.3333333333%;
     left: auto; }
-
   .small-push-2 {
     position: relative;
-    left: 16.66667%;
+    left: 16.6666666667%;
     right: auto; }
-
   .small-pull-2 {
     position: relative;
-    right: 16.66667%;
+    right: 16.6666666667%;
     left: auto; }
-
   .small-push-3 {
     position: relative;
     left: 25%;
     right: auto; }
-
   .small-pull-3 {
     position: relative;
     right: 25%;
     left: auto; }
-
   .small-push-4 {
     position: relative;
-    left: 33.33333%;
+    left: 33.3333333333%;
     right: auto; }
-
   .small-pull-4 {
     position: relative;
-    right: 33.33333%;
+    right: 33.3333333333%;
     left: auto; }
-
   .small-push-5 {
     position: relative;
-    left: 41.66667%;
+    left: 41.6666666667%;
     right: auto; }
-
   .small-pull-5 {
     position: relative;
-    right: 41.66667%;
+    right: 41.6666666667%;
     left: auto; }
-
   .small-push-6 {
     position: relative;
     left: 50%;
     right: auto; }
-
   .small-pull-6 {
     position: relative;
     right: 50%;
     left: auto; }
-
   .small-push-7 {
     position: relative;
-    left: 58.33333%;
+    left: 58.3333333333%;
     right: auto; }
-
   .small-pull-7 {
     position: relative;
-    right: 58.33333%;
+    right: 58.3333333333%;
     left: auto; }
-
   .small-push-8 {
     position: relative;
-    left: 66.66667%;
+    left: 66.6666666667%;
     right: auto; }
-
   .small-pull-8 {
     position: relative;
-    right: 66.66667%;
+    right: 66.6666666667%;
     left: auto; }
-
   .small-push-9 {
     position: relative;
     left: 75%;
     right: auto; }
-
   .small-pull-9 {
     position: relative;
     right: 75%;
     left: auto; }
-
   .small-push-10 {
     position: relative;
-    left: 83.33333%;
+    left: 83.3333333333%;
     right: auto; }
-
   .small-pull-10 {
     position: relative;
-    right: 83.33333%;
+    right: 83.3333333333%;
     left: auto; }
-
   .small-push-11 {
     position: relative;
-    left: 91.66667%;
+    left: 91.6666666667%;
     right: auto; }
-
   .small-pull-11 {
     position: relative;
-    right: 91.66667%;
+    right: 91.6666666667%;
     left: auto; }
-
   .column,
   .columns {
     position: relative;
     padding-left: 0.9375rem;
     padding-right: 0.9375rem;
     float: left; }
-
   .small-1 {
-    width: 8.33333%; }
-
+    width: 8.3333333333%; }
   .small-2 {
-    width: 16.66667%; }
-
+    width: 16.6666666667%; }
   .small-3 {
     width: 25%; }
-
   .small-4 {
-    width: 33.33333%; }
-
+    width: 33.3333333333%; }
   .small-5 {
-    width: 41.66667%; }
-
+    width: 41.6666666667%; }
   .small-6 {
     width: 50%; }
-
   .small-7 {
-    width: 58.33333%; }
-
+    width: 58.3333333333%; }
   .small-8 {
-    width: 66.66667%; }
-
+    width: 66.6666666667%; }
   .small-9 {
     width: 75%; }
-
   .small-10 {
-    width: 83.33333%; }
-
+    width: 83.3333333333%; }
   .small-11 {
-    width: 91.66667%; }
-
+    width: 91.6666666667%; }
   .small-12 {
     width: 100%; }
-
   .small-offset-0 {
     margin-left: 0 !important; }
-
   .small-offset-1 {
-    margin-left: 8.33333% !important; }
-
+    margin-left: 8.3333333333% !important; }
   .small-offset-2 {
-    margin-left: 16.66667% !important; }
-
+    margin-left: 16.6666666667% !important; }
   .small-offset-3 {
     margin-left: 25% !important; }
-
   .small-offset-4 {
-    margin-left: 33.33333% !important; }
-
+    margin-left: 33.3333333333% !important; }
   .small-offset-5 {
-    margin-left: 41.66667% !important; }
-
+    margin-left: 41.6666666667% !important; }
   .small-offset-6 {
     margin-left: 50% !important; }
-
   .small-offset-7 {
-    margin-left: 58.33333% !important; }
-
+    margin-left: 58.3333333333% !important; }
   .small-offset-8 {
-    margin-left: 66.66667% !important; }
-
+    margin-left: 66.6666666667% !important; }
   .small-offset-9 {
     margin-left: 75% !important; }
-
   .small-offset-10 {
-    margin-left: 83.33333% !important; }
-
+    margin-left: 83.3333333333% !important; }
   .small-offset-11 {
-    margin-left: 91.66667% !important; }
-
+    margin-left: 91.6666666667% !important; }
   .small-reset-order {
     float: left;
     left: auto;
     margin-left: 0;
     margin-right: 0;
     right: auto; }
-
   .column.small-centered,
   .columns.small-centered {
     margin-left: auto;
     margin-right: auto;
     float: none; }
-
   .column.small-uncentered,
   .columns.small-uncentered {
     float: left;
     margin-left: 0;
     margin-right: 0; }
-
   .column.small-centered:last-child,
   .columns.small-centered:last-child {
     float: none; }
-
   .column.small-uncentered:last-child,
   .columns.small-uncentered:last-child {
     float: left; }
-
   .column.small-uncentered.opposite,
   .columns.small-uncentered.opposite {
     float: right; }
-
   .row.small-collapse > .column,
   .row.small-collapse > .columns {
     padding-left: 0;
@@ -418,237 +365,183 @@ select {
     padding-left: 0.9375rem;
     padding-right: 0.9375rem;
     float: left; } }
+
 @media only screen and (min-width: 40.0625em) {
   .medium-push-0 {
     position: relative;
     left: 0;
     right: auto; }
-
   .medium-pull-0 {
     position: relative;
     right: 0;
     left: auto; }
-
   .medium-push-1 {
     position: relative;
-    left: 8.33333%;
+    left: 8.3333333333%;
     right: auto; }
-
   .medium-pull-1 {
     position: relative;
-    right: 8.33333%;
+    right: 8.3333333333%;
     left: auto; }
-
   .medium-push-2 {
     position: relative;
-    left: 16.66667%;
+    left: 16.6666666667%;
     right: auto; }
-
   .medium-pull-2 {
     position: relative;
-    right: 16.66667%;
+    right: 16.6666666667%;
     left: auto; }
-
   .medium-push-3 {
     position: relative;
     left: 25%;
     right: auto; }
-
   .medium-pull-3 {
     position: relative;
     right: 25%;
     left: auto; }
-
   .medium-push-4 {
     position: relative;
-    left: 33.33333%;
+    left: 33.3333333333%;
     right: auto; }
-
   .medium-pull-4 {
     position: relative;
-    right: 33.33333%;
+    right: 33.3333333333%;
     left: auto; }
-
   .medium-push-5 {
     position: relative;
-    left: 41.66667%;
+    left: 41.6666666667%;
     right: auto; }
-
   .medium-pull-5 {
     position: relative;
-    right: 41.66667%;
+    right: 41.6666666667%;
     left: auto; }
-
   .medium-push-6 {
     position: relative;
     left: 50%;
     right: auto; }
-
   .medium-pull-6 {
     position: relative;
     right: 50%;
     left: auto; }
-
   .medium-push-7 {
     position: relative;
-    left: 58.33333%;
+    left: 58.3333333333%;
     right: auto; }
-
   .medium-pull-7 {
     position: relative;
-    right: 58.33333%;
+    right: 58.3333333333%;
     left: auto; }
-
   .medium-push-8 {
     position: relative;
-    left: 66.66667%;
+    left: 66.6666666667%;
     right: auto; }
-
   .medium-pull-8 {
     position: relative;
-    right: 66.66667%;
+    right: 66.6666666667%;
     left: auto; }
-
   .medium-push-9 {
     position: relative;
     left: 75%;
     right: auto; }
-
   .medium-pull-9 {
     position: relative;
     right: 75%;
     left: auto; }
-
   .medium-push-10 {
     position: relative;
-    left: 83.33333%;
+    left: 83.3333333333%;
     right: auto; }
-
   .medium-pull-10 {
     position: relative;
-    right: 83.33333%;
+    right: 83.3333333333%;
     left: auto; }
-
   .medium-push-11 {
     position: relative;
-    left: 91.66667%;
+    left: 91.6666666667%;
     right: auto; }
-
   .medium-pull-11 {
     position: relative;
-    right: 91.66667%;
+    right: 91.6666666667%;
     left: auto; }
-
   .column,
   .columns {
     position: relative;
     padding-left: 0.9375rem;
     padding-right: 0.9375rem;
     float: left; }
-
   .medium-1 {
-    width: 8.33333%; }
-
+    width: 8.3333333333%; }
   .medium-2 {
-    width: 16.66667%; }
-
+    width: 16.6666666667%; }
   .medium-3 {
     width: 25%; }
-
   .medium-4 {
-    width: 33.33333%; }
-
+    width: 33.3333333333%; }
   .medium-5 {
-    width: 41.66667%; }
-
+    width: 41.6666666667%; }
   .medium-6 {
     width: 50%; }
-
   .medium-7 {
-    width: 58.33333%; }
-
+    width: 58.3333333333%; }
   .medium-8 {
-    width: 66.66667%; }
-
+    width: 66.6666666667%; }
   .medium-9 {
     width: 75%; }
-
   .medium-10 {
-    width: 83.33333%; }
-
+    width: 83.3333333333%; }
   .medium-11 {
-    width: 91.66667%; }
-
+    width: 91.6666666667%; }
   .medium-12 {
     width: 100%; }
-
   .medium-offset-0 {
     margin-left: 0 !important; }
-
   .medium-offset-1 {
-    margin-left: 8.33333% !important; }
-
+    margin-left: 8.3333333333% !important; }
   .medium-offset-2 {
-    margin-left: 16.66667% !important; }
-
+    margin-left: 16.6666666667% !important; }
   .medium-offset-3 {
     margin-left: 25% !important; }
-
   .medium-offset-4 {
-    margin-left: 33.33333% !important; }
-
+    margin-left: 33.3333333333% !important; }
   .medium-offset-5 {
-    margin-left: 41.66667% !important; }
-
+    margin-left: 41.6666666667% !important; }
   .medium-offset-6 {
     margin-left: 50% !important; }
-
   .medium-offset-7 {
-    margin-left: 58.33333% !important; }
-
+    margin-left: 58.3333333333% !important; }
   .medium-offset-8 {
-    margin-left: 66.66667% !important; }
-
+    margin-left: 66.6666666667% !important; }
   .medium-offset-9 {
     margin-left: 75% !important; }
-
   .medium-offset-10 {
-    margin-left: 83.33333% !important; }
-
+    margin-left: 83.3333333333% !important; }
   .medium-offset-11 {
-    margin-left: 91.66667% !important; }
-
+    margin-left: 91.6666666667% !important; }
   .medium-reset-order {
     float: left;
     left: auto;
     margin-left: 0;
     margin-right: 0;
     right: auto; }
-
   .column.medium-centered,
   .columns.medium-centered {
     margin-left: auto;
     margin-right: auto;
     float: none; }
-
   .column.medium-uncentered,
   .columns.medium-uncentered {
     float: left;
     margin-left: 0;
     margin-right: 0; }
-
   .column.medium-centered:last-child,
   .columns.medium-centered:last-child {
     float: none; }
-
   .column.medium-uncentered:last-child,
   .columns.medium-uncentered:last-child {
     float: left; }
-
   .column.medium-uncentered.opposite,
   .columns.medium-uncentered.opposite {
     float: right; }
-
   .row.medium-collapse > .column,
   .row.medium-collapse > .columns {
     padding-left: 0;
@@ -661,357 +554,279 @@ select {
     padding-left: 0.9375rem;
     padding-right: 0.9375rem;
     float: left; }
-
   .push-0 {
     position: relative;
     left: 0;
     right: auto; }
-
   .pull-0 {
     position: relative;
     right: 0;
     left: auto; }
-
   .push-1 {
     position: relative;
-    left: 8.33333%;
+    left: 8.3333333333%;
     right: auto; }
-
   .pull-1 {
     position: relative;
-    right: 8.33333%;
+    right: 8.3333333333%;
     left: auto; }
-
   .push-2 {
     position: relative;
-    left: 16.66667%;
+    left: 16.6666666667%;
     right: auto; }
-
   .pull-2 {
     position: relative;
-    right: 16.66667%;
+    right: 16.6666666667%;
     left: auto; }
-
   .push-3 {
     position: relative;
     left: 25%;
     right: auto; }
-
   .pull-3 {
     position: relative;
     right: 25%;
     left: auto; }
-
   .push-4 {
     position: relative;
-    left: 33.33333%;
+    left: 33.3333333333%;
     right: auto; }
-
   .pull-4 {
     position: relative;
-    right: 33.33333%;
+    right: 33.3333333333%;
     left: auto; }
-
   .push-5 {
     position: relative;
-    left: 41.66667%;
+    left: 41.6666666667%;
     right: auto; }
-
   .pull-5 {
     position: relative;
-    right: 41.66667%;
+    right: 41.6666666667%;
     left: auto; }
-
   .push-6 {
     position: relative;
     left: 50%;
     right: auto; }
-
   .pull-6 {
     position: relative;
     right: 50%;
     left: auto; }
-
   .push-7 {
     position: relative;
-    left: 58.33333%;
+    left: 58.3333333333%;
     right: auto; }
-
   .pull-7 {
     position: relative;
-    right: 58.33333%;
+    right: 58.3333333333%;
     left: auto; }
-
   .push-8 {
     position: relative;
-    left: 66.66667%;
+    left: 66.6666666667%;
     right: auto; }
-
   .pull-8 {
     position: relative;
-    right: 66.66667%;
+    right: 66.6666666667%;
     left: auto; }
-
   .push-9 {
     position: relative;
     left: 75%;
     right: auto; }
-
   .pull-9 {
     position: relative;
     right: 75%;
     left: auto; }
-
   .push-10 {
     position: relative;
-    left: 83.33333%;
+    left: 83.3333333333%;
     right: auto; }
-
   .pull-10 {
     position: relative;
-    right: 83.33333%;
+    right: 83.3333333333%;
     left: auto; }
-
   .push-11 {
     position: relative;
-    left: 91.66667%;
+    left: 91.6666666667%;
     right: auto; }
-
   .pull-11 {
     position: relative;
-    right: 91.66667%;
+    right: 91.6666666667%;
     left: auto; } }
+
 @media only screen and (min-width: 64.0625em) {
   .large-push-0 {
     position: relative;
     left: 0;
     right: auto; }
-
   .large-pull-0 {
     position: relative;
     right: 0;
     left: auto; }
-
   .large-push-1 {
     position: relative;
-    left: 8.33333%;
+    left: 8.3333333333%;
     right: auto; }
-
   .large-pull-1 {
     position: relative;
-    right: 8.33333%;
+    right: 8.3333333333%;
     left: auto; }
-
   .large-push-2 {
     position: relative;
-    left: 16.66667%;
+    left: 16.6666666667%;
     right: auto; }
-
   .large-pull-2 {
     position: relative;
-    right: 16.66667%;
+    right: 16.6666666667%;
     left: auto; }
-
   .large-push-3 {
     position: relative;
     left: 25%;
     right: auto; }
-
   .large-pull-3 {
     position: relative;
     right: 25%;
     left: auto; }
-
   .large-push-4 {
     position: relative;
-    left: 33.33333%;
+    left: 33.3333333333%;
     right: auto; }
-
   .large-pull-4 {
     position: relative;
-    right: 33.33333%;
+    right: 33.3333333333%;
     left: auto; }
-
   .large-push-5 {
     position: relative;
-    left: 41.66667%;
+    left: 41.6666666667%;
     right: auto; }
-
   .large-pull-5 {
     position: relative;
-    right: 41.66667%;
+    right: 41.6666666667%;
     left: auto; }
-
   .large-push-6 {
     position: relative;
     left: 50%;
     right: auto; }
-
   .large-pull-6 {
     position: relative;
     right: 50%;
     left: auto; }
-
   .large-push-7 {
     position: relative;
-    left: 58.33333%;
+    left: 58.3333333333%;
     right: auto; }
-
   .large-pull-7 {
     position: relative;
-    right: 58.33333%;
+    right: 58.3333333333%;
     left: auto; }
-
   .large-push-8 {
     position: relative;
-    left: 66.66667%;
+    left: 66.6666666667%;
     right: auto; }
-
   .large-pull-8 {
     position: relative;
-    right: 66.66667%;
+    right: 66.6666666667%;
     left: auto; }
-
   .large-push-9 {
     position: relative;
     left: 75%;
     right: auto; }
-
   .large-pull-9 {
     position: relative;
     right: 75%;
     left: auto; }
-
   .large-push-10 {
     position: relative;
-    left: 83.33333%;
+    left: 83.3333333333%;
     right: auto; }
-
   .large-pull-10 {
     position: relative;
-    right: 83.33333%;
+    right: 83.3333333333%;
     left: auto; }
-
   .large-push-11 {
     position: relative;
-    left: 91.66667%;
+    left: 91.6666666667%;
     right: auto; }
-
   .large-pull-11 {
     position: relative;
-    right: 91.66667%;
+    right: 91.6666666667%;
     left: auto; }
-
   .column,
   .columns {
     position: relative;
     padding-left: 0.9375rem;
     padding-right: 0.9375rem;
     float: left; }
-
   .large-1 {
-    width: 8.33333%; }
-
+    width: 8.3333333333%; }
   .large-2 {
-    width: 16.66667%; }
-
+    width: 16.6666666667%; }
   .large-3 {
     width: 25%; }
-
   .large-4 {
-    width: 33.33333%; }
-
+    width: 33.3333333333%; }
   .large-5 {
-    width: 41.66667%; }
-
+    width: 41.6666666667%; }
   .large-6 {
     width: 50%; }
-
   .large-7 {
-    width: 58.33333%; }
-
+    width: 58.3333333333%; }
   .large-8 {
-    width: 66.66667%; }
-
+    width: 66.6666666667%; }
   .large-9 {
     width: 75%; }
-
   .large-10 {
-    width: 83.33333%; }
-
+    width: 83.3333333333%; }
   .large-11 {
-    width: 91.66667%; }
-
+    width: 91.6666666667%; }
   .large-12 {
     width: 100%; }
-
   .large-offset-0 {
     margin-left: 0 !important; }
-
   .large-offset-1 {
-    margin-left: 8.33333% !important; }
-
+    margin-left: 8.3333333333% !important; }
   .large-offset-2 {
-    margin-left: 16.66667% !important; }
-
+    margin-left: 16.6666666667% !important; }
   .large-offset-3 {
     margin-left: 25% !important; }
-
   .large-offset-4 {
-    margin-left: 33.33333% !important; }
-
+    margin-left: 33.3333333333% !important; }
   .large-offset-5 {
-    margin-left: 41.66667% !important; }
-
+    margin-left: 41.6666666667% !important; }
   .large-offset-6 {
     margin-left: 50% !important; }
-
   .large-offset-7 {
-    margin-left: 58.33333% !important; }
-
+    margin-left: 58.3333333333% !important; }
   .large-offset-8 {
-    margin-left: 66.66667% !important; }
-
+    margin-left: 66.6666666667% !important; }
   .large-offset-9 {
     margin-left: 75% !important; }
-
   .large-offset-10 {
-    margin-left: 83.33333% !important; }
-
+    margin-left: 83.3333333333% !important; }
   .large-offset-11 {
-    margin-left: 91.66667% !important; }
-
+    margin-left: 91.6666666667% !important; }
   .large-reset-order {
     float: left;
     left: auto;
     margin-left: 0;
     margin-right: 0;
     right: auto; }
-
   .column.large-centered,
   .columns.large-centered {
     margin-left: auto;
     margin-right: auto;
     float: none; }
-
   .column.large-uncentered,
   .columns.large-uncentered {
     float: left;
     margin-left: 0;
     margin-right: 0; }
-
   .column.large-centered:last-child,
   .columns.large-centered:last-child {
     float: none; }
-
   .column.large-uncentered:last-child,
   .columns.large-uncentered:last-child {
     float: left; }
-
   .column.large-uncentered.opposite,
   .columns.large-uncentered.opposite {
     float: right; }
-
   .row.large-collapse > .column,
   .row.large-collapse > .columns {
     padding-left: 0;
@@ -1024,126 +839,103 @@ select {
     padding-left: 0.9375rem;
     padding-right: 0.9375rem;
     float: left; }
-
   .push-0 {
     position: relative;
     left: 0;
     right: auto; }
-
   .pull-0 {
     position: relative;
     right: 0;
     left: auto; }
-
   .push-1 {
     position: relative;
-    left: 8.33333%;
+    left: 8.3333333333%;
     right: auto; }
-
   .pull-1 {
     position: relative;
-    right: 8.33333%;
+    right: 8.3333333333%;
     left: auto; }
-
   .push-2 {
     position: relative;
-    left: 16.66667%;
+    left: 16.6666666667%;
     right: auto; }
-
   .pull-2 {
     position: relative;
-    right: 16.66667%;
+    right: 16.6666666667%;
     left: auto; }
-
   .push-3 {
     position: relative;
     left: 25%;
     right: auto; }
-
   .pull-3 {
     position: relative;
     right: 25%;
     left: auto; }
-
   .push-4 {
     position: relative;
-    left: 33.33333%;
+    left: 33.3333333333%;
     right: auto; }
-
   .pull-4 {
     position: relative;
-    right: 33.33333%;
+    right: 33.3333333333%;
     left: auto; }
-
   .push-5 {
     position: relative;
-    left: 41.66667%;
+    left: 41.6666666667%;
     right: auto; }
-
   .pull-5 {
     position: relative;
-    right: 41.66667%;
+    right: 41.6666666667%;
     left: auto; }
-
   .push-6 {
     position: relative;
     left: 50%;
     right: auto; }
-
   .pull-6 {
     position: relative;
     right: 50%;
     left: auto; }
-
   .push-7 {
     position: relative;
-    left: 58.33333%;
+    left: 58.3333333333%;
     right: auto; }
-
   .pull-7 {
     position: relative;
-    right: 58.33333%;
+    right: 58.3333333333%;
     left: auto; }
-
   .push-8 {
     position: relative;
-    left: 66.66667%;
+    left: 66.6666666667%;
     right: auto; }
-
   .pull-8 {
     position: relative;
-    right: 66.66667%;
+    right: 66.6666666667%;
     left: auto; }
-
   .push-9 {
     position: relative;
     left: 75%;
     right: auto; }
-
   .pull-9 {
     position: relative;
     right: 75%;
     left: auto; }
-
   .push-10 {
     position: relative;
-    left: 83.33333%;
+    left: 83.3333333333%;
     right: auto; }
-
   .pull-10 {
     position: relative;
-    right: 83.33333%;
+    right: 83.3333333333%;
     left: auto; }
-
   .push-11 {
     position: relative;
-    left: 91.66667%;
+    left: 91.6666666667%;
     right: auto; }
-
   .pull-11 {
     position: relative;
-    right: 91.66667%;
+    right: 91.6666666667%;
     left: auto; } }
+
 .accordion {
   margin-bottom: 0;
   margin-left: 0; }
@@ -1250,7 +1042,6 @@ select {
       clear: none; }
     .small-block-grid-1 > li:nth-of-type(1n+1) {
       clear: both; }
-
   .small-block-grid-2 > li {
     list-style: none;
     width: 50%; }
@@ -1258,15 +1049,13 @@ select {
       clear: none; }
     .small-block-grid-2 > li:nth-of-type(2n+1) {
       clear: both; }
-
   .small-block-grid-3 > li {
     list-style: none;
-    width: 33.33333%; }
+    width: 33.3333333333%; }
     .small-block-grid-3 > li:nth-of-type(1n) {
       clear: none; }
     .small-block-grid-3 > li:nth-of-type(3n+1) {
       clear: both; }
-
   .small-block-grid-4 > li {
     list-style: none;
     width: 25%; }
@@ -1274,7 +1063,6 @@ select {
       clear: none; }
     .small-block-grid-4 > li:nth-of-type(4n+1) {
       clear: both; }
-
   .small-block-grid-5 > li {
     list-style: none;
     width: 20%; }
@@ -1282,23 +1070,20 @@ select {
       clear: none; }
     .small-block-grid-5 > li:nth-of-type(5n+1) {
       clear: both; }
-
   .small-block-grid-6 > li {
     list-style: none;
-    width: 16.66667%; }
+    width: 16.6666666667%; }
     .small-block-grid-6 > li:nth-of-type(1n) {
       clear: none; }
     .small-block-grid-6 > li:nth-of-type(6n+1) {
       clear: both; }
-
   .small-block-grid-7 > li {
     list-style: none;
-    width: 14.28571%; }
+    width: 14.2857142857%; }
     .small-block-grid-7 > li:nth-of-type(1n) {
       clear: none; }
     .small-block-grid-7 > li:nth-of-type(7n+1) {
       clear: both; }
-
   .small-block-grid-8 > li {
     list-style: none;
     width: 12.5%; }
@@ -1306,15 +1091,13 @@ select {
       clear: none; }
     .small-block-grid-8 > li:nth-of-type(8n+1) {
       clear: both; }
-
   .small-block-grid-9 > li {
     list-style: none;
-    width: 11.11111%; }
+    width: 11.1111111111%; }
     .small-block-grid-9 > li:nth-of-type(1n) {
       clear: none; }
     .small-block-grid-9 > li:nth-of-type(9n+1) {
       clear: both; }
-
   .small-block-grid-10 > li {
     list-style: none;
     width: 10%; }
@@ -1322,22 +1105,21 @@ select {
       clear: none; }
     .small-block-grid-10 > li:nth-of-type(10n+1) {
       clear: both; }
-
   .small-block-grid-11 > li {
     list-style: none;
-    width: 9.09091%; }
+    width: 9.0909090909%; }
     .small-block-grid-11 > li:nth-of-type(1n) {
       clear: none; }
     .small-block-grid-11 > li:nth-of-type(11n+1) {
       clear: both; }
-
   .small-block-grid-12 > li {
     list-style: none;
-    width: 8.33333%; }
+    width: 8.3333333333%; }
     .small-block-grid-12 > li:nth-of-type(1n) {
       clear: none; }
     .small-block-grid-12 > li:nth-of-type(12n+1) {
       clear: both; } }
+
 @media only screen and (min-width: 40.0625em) {
   .medium-block-grid-1 > li {
     list-style: none;
@@ -1346,7 +1128,6 @@ select {
       clear: none; }
     .medium-block-grid-1 > li:nth-of-type(1n+1) {
       clear: both; }
-
   .medium-block-grid-2 > li {
     list-style: none;
     width: 50%; }
@@ -1354,15 +1135,13 @@ select {
       clear: none; }
     .medium-block-grid-2 > li:nth-of-type(2n+1) {
       clear: both; }
-
   .medium-block-grid-3 > li {
     list-style: none;
-    width: 33.33333%; }
+    width: 33.3333333333%; }
     .medium-block-grid-3 > li:nth-of-type(1n) {
       clear: none; }
     .medium-block-grid-3 > li:nth-of-type(3n+1) {
       clear: both; }
-
   .medium-block-grid-4 > li {
     list-style: none;
     width: 25%; }
@@ -1370,7 +1149,6 @@ select {
       clear: none; }
     .medium-block-grid-4 > li:nth-of-type(4n+1) {
       clear: both; }
-
   .medium-block-grid-5 > li {
     list-style: none;
     width: 20%; }
@@ -1378,23 +1156,20 @@ select {
       clear: none; }
     .medium-block-grid-5 > li:nth-of-type(5n+1) {
       clear: both; }
-
   .medium-block-grid-6 > li {
     list-style: none;
-    width: 16.66667%; }
+    width: 16.6666666667%; }
     .medium-block-grid-6 > li:nth-of-type(1n) {
       clear: none; }
     .medium-block-grid-6 > li:nth-of-type(6n+1) {
       clear: both; }
-
   .medium-block-grid-7 > li {
     list-style: none;
-    width: 14.28571%; }
+    width: 14.2857142857%; }
     .medium-block-grid-7 > li:nth-of-type(1n) {
       clear: none; }
     .medium-block-grid-7 > li:nth-of-type(7n+1) {
       clear: both; }
-
   .medium-block-grid-8 > li {
     list-style: none;
     width: 12.5%; }
@@ -1402,15 +1177,13 @@ select {
       clear: none; }
     .medium-block-grid-8 > li:nth-of-type(8n+1) {
       clear: both; }
-
   .medium-block-grid-9 > li {
     list-style: none;
-    width: 11.11111%; }
+    width: 11.1111111111%; }
     .medium-block-grid-9 > li:nth-of-type(1n) {
       clear: none; }
     .medium-block-grid-9 > li:nth-of-type(9n+1) {
       clear: both; }
-
   .medium-block-grid-10 > li {
     list-style: none;
     width: 10%; }
@@ -1418,22 +1191,21 @@ select {
       clear: none; }
     .medium-block-grid-10 > li:nth-of-type(10n+1) {
       clear: both; }
-
   .medium-block-grid-11 > li {
     list-style: none;
-    width: 9.09091%; }
+    width: 9.0909090909%; }
     .medium-block-grid-11 > li:nth-of-type(1n) {
       clear: none; }
     .medium-block-grid-11 > li:nth-of-type(11n+1) {
       clear: both; }
-
   .medium-block-grid-12 > li {
     list-style: none;
-    width: 8.33333%; }
+    width: 8.3333333333%; }
     .medium-block-grid-12 > li:nth-of-type(1n) {
       clear: none; }
     .medium-block-grid-12 > li:nth-of-type(12n+1) {
       clear: both; } }
+
 @media only screen and (min-width: 64.0625em) {
   .large-block-grid-1 > li {
     list-style: none;
@@ -1442,7 +1214,6 @@ select {
       clear: none; }
     .large-block-grid-1 > li:nth-of-type(1n+1) {
       clear: both; }
-
   .large-block-grid-2 > li {
     list-style: none;
     width: 50%; }
@@ -1450,15 +1221,13 @@ select {
       clear: none; }
     .large-block-grid-2 > li:nth-of-type(2n+1) {
       clear: both; }
-
   .large-block-grid-3 > li {
     list-style: none;
-    width: 33.33333%; }
+    width: 33.3333333333%; }
     .large-block-grid-3 > li:nth-of-type(1n) {
       clear: none; }
     .large-block-grid-3 > li:nth-of-type(3n+1) {
       clear: both; }
-
   .large-block-grid-4 > li {
     list-style: none;
     width: 25%; }
@@ -1466,7 +1235,6 @@ select {
       clear: none; }
     .large-block-grid-4 > li:nth-of-type(4n+1) {
       clear: both; }
-
   .large-block-grid-5 > li {
     list-style: none;
     width: 20%; }
@@ -1474,23 +1242,20 @@ select {
       clear: none; }
     .large-block-grid-5 > li:nth-of-type(5n+1) {
       clear: both; }
-
   .large-block-grid-6 > li {
     list-style: none;
-    width: 16.66667%; }
+    width: 16.6666666667%; }
     .large-block-grid-6 > li:nth-of-type(1n) {
       clear: none; }
     .large-block-grid-6 > li:nth-of-type(6n+1) {
       clear: both; }
-
   .large-block-grid-7 > li {
     list-style: none;
-    width: 14.28571%; }
+    width: 14.2857142857%; }
     .large-block-grid-7 > li:nth-of-type(1n) {
       clear: none; }
     .large-block-grid-7 > li:nth-of-type(7n+1) {
       clear: both; }
-
   .large-block-grid-8 > li {
     list-style: none;
     width: 12.5%; }
@@ -1498,15 +1263,13 @@ select {
       clear: none; }
     .large-block-grid-8 > li:nth-of-type(8n+1) {
       clear: both; }
-
   .large-block-grid-9 > li {
     list-style: none;
-    width: 11.11111%; }
+    width: 11.1111111111%; }
     .large-block-grid-9 > li:nth-of-type(1n) {
       clear: none; }
     .large-block-grid-9 > li:nth-of-type(9n+1) {
       clear: both; }
-
   .large-block-grid-10 > li {
     list-style: none;
     width: 10%; }
@@ -1514,22 +1277,21 @@ select {
       clear: none; }
     .large-block-grid-10 > li:nth-of-type(10n+1) {
       clear: both; }
-
   .large-block-grid-11 > li {
     list-style: none;
-    width: 9.09091%; }
+    width: 9.0909090909%; }
     .large-block-grid-11 > li:nth-of-type(1n) {
       clear: none; }
     .large-block-grid-11 > li:nth-of-type(11n+1) {
       clear: both; }
-
   .large-block-grid-12 > li {
     list-style: none;
-    width: 8.33333%; }
+    width: 8.3333333333%; }
     .large-block-grid-12 > li:nth-of-type(1n) {
       clear: none; }
     .large-block-grid-12 > li:nth-of-type(12n+1) {
       clear: both; } }
+
 .breadcrumbs {
   border-style: solid;
   border-width: 1px;
@@ -1564,7 +1326,8 @@ select {
       color: #999999; }
       .breadcrumbs > *.unavailable a {
         color: #999999; }
-      .breadcrumbs > *.unavailable:hover, .breadcrumbs > *.unavailable:hover a, .breadcrumbs > *.unavailable:focus,
+      .breadcrumbs > *.unavailable:hover,
+      .breadcrumbs > *.unavailable:hover a, .breadcrumbs > *.unavailable:focus,
       .breadcrumbs > *.unavailable a:focus {
         color: #999999;
         cursor: not-allowed;
@@ -1761,6 +1524,7 @@ button::-moz-focus-inner {
 @media only screen and (min-width: 40.0625em) {
   button, .button {
     display: inline-block; } }
+
 .button-group {
   list-style: none;
   margin: 0;
@@ -1784,7 +1548,7 @@ button::-moz-focus-inner {
   .button-group.even-3 li {
     display: inline-block;
     margin: 0 -2px;
-    width: 33.33333%; }
+    width: 33.3333333333%; }
     .button-group.even-3 li > button, .button-group.even-3 li .button {
       border-left: 1px solid;
       border-color: rgba(255, 255, 255, 0.5); }
@@ -1817,7 +1581,7 @@ button::-moz-focus-inner {
   .button-group.even-6 li {
     display: inline-block;
     margin: 0 -2px;
-    width: 16.66667%; }
+    width: 16.6666666667%; }
     .button-group.even-6 li > button, .button-group.even-6 li .button {
       border-left: 1px solid;
       border-color: rgba(255, 255, 255, 0.5); }
@@ -1828,7 +1592,7 @@ button::-moz-focus-inner {
   .button-group.even-7 li {
     display: inline-block;
     margin: 0 -2px;
-    width: 14.28571%; }
+    width: 14.2857142857%; }
     .button-group.even-7 li > button, .button-group.even-7 li .button {
       border-left: 1px solid;
       border-color: rgba(255, 255, 255, 0.5); }
@@ -1915,12 +1679,18 @@ button::-moz-focus-inner {
     .button-group.radius > * > button,
     .button-group.radius > * > .button {
       border-radius: 0; }
-    .button-group.radius > *:first-child, .button-group.radius > *:first-child > a, .button-group.radius > *:first-child > button, .button-group.radius > *:first-child > .button {
+    .button-group.radius > *:first-child,
+    .button-group.radius > *:first-child > a,
+    .button-group.radius > *:first-child > button,
+    .button-group.radius > *:first-child > .button {
       -webkit-border-bottom-left-radius: 3px;
       -webkit-border-top-left-radius: 3px;
       border-bottom-left-radius: 3px;
       border-top-left-radius: 3px; }
-    .button-group.radius > *:last-child, .button-group.radius > *:last-child > a, .button-group.radius > *:last-child > button, .button-group.radius > *:last-child > .button {
+    .button-group.radius > *:last-child,
+    .button-group.radius > *:last-child > a,
+    .button-group.radius > *:last-child > button,
+    .button-group.radius > *:last-child > .button {
       -webkit-border-bottom-right-radius: 3px;
       -webkit-border-top-right-radius: 3px;
       border-bottom-right-radius: 3px;
@@ -1948,12 +1718,18 @@ button::-moz-focus-inner {
     .button-group.radius.stack > * > button,
     .button-group.radius.stack > * > .button {
       border-radius: 0; }
-    .button-group.radius.stack > *:first-child, .button-group.radius.stack > *:first-child > a, .button-group.radius.stack > *:first-child > button, .button-group.radius.stack > *:first-child > .button {
+    .button-group.radius.stack > *:first-child,
+    .button-group.radius.stack > *:first-child > a,
+    .button-group.radius.stack > *:first-child > button,
+    .button-group.radius.stack > *:first-child > .button {
       -webkit-top-left-radius: 3px;
       -webkit-top-right-radius: 3px;
       border-top-left-radius: 3px;
       border-top-right-radius: 3px; }
-    .button-group.radius.stack > *:last-child, .button-group.radius.stack > *:last-child > a, .button-group.radius.stack > *:last-child > button, .button-group.radius.stack > *:last-child > .button {
+    .button-group.radius.stack > *:last-child,
+    .button-group.radius.stack > *:last-child > a,
+    .button-group.radius.stack > *:last-child > button,
+    .button-group.radius.stack > *:last-child > .button {
       -webkit-bottom-left-radius: 3px;
       -webkit-bottom-right-radius: 3px;
       border-bottom-left-radius: 3px;
@@ -1972,12 +1748,18 @@ button::-moz-focus-inner {
       .button-group.radius.stack-for-small > * > button,
       .button-group.radius.stack-for-small > * > .button {
         border-radius: 0; }
-      .button-group.radius.stack-for-small > *:first-child, .button-group.radius.stack-for-small > *:first-child > a, .button-group.radius.stack-for-small > *:first-child > button, .button-group.radius.stack-for-small > *:first-child > .button {
+      .button-group.radius.stack-for-small > *:first-child,
+      .button-group.radius.stack-for-small > *:first-child > a,
+      .button-group.radius.stack-for-small > *:first-child > button,
+      .button-group.radius.stack-for-small > *:first-child > .button {
         -webkit-border-bottom-left-radius: 3px;
         -webkit-border-top-left-radius: 3px;
         border-bottom-left-radius: 3px;
         border-top-left-radius: 3px; }
-      .button-group.radius.stack-for-small > *:last-child, .button-group.radius.stack-for-small > *:last-child > a, .button-group.radius.stack-for-small > *:last-child > button, .button-group.radius.stack-for-small > *:last-child > .button {
+      .button-group.radius.stack-for-small > *:last-child,
+      .button-group.radius.stack-for-small > *:last-child > a,
+      .button-group.radius.stack-for-small > *:last-child > button,
+      .button-group.radius.stack-for-small > *:last-child > .button {
         -webkit-border-bottom-right-radius: 3px;
         -webkit-border-top-right-radius: 3px;
         border-bottom-right-radius: 3px;
@@ -2006,12 +1788,18 @@ button::-moz-focus-inner {
       .button-group.radius.stack-for-small > * > button,
       .button-group.radius.stack-for-small > * > .button {
         border-radius: 0; }
-      .button-group.radius.stack-for-small > *:first-child, .button-group.radius.stack-for-small > *:first-child > a, .button-group.radius.stack-for-small > *:first-child > button, .button-group.radius.stack-for-small > *:first-child > .button {
+      .button-group.radius.stack-for-small > *:first-child,
+      .button-group.radius.stack-for-small > *:first-child > a,
+      .button-group.radius.stack-for-small > *:first-child > button,
+      .button-group.radius.stack-for-small > *:first-child > .button {
         -webkit-top-left-radius: 3px;
         -webkit-top-right-radius: 3px;
         border-top-left-radius: 3px;
         border-top-right-radius: 3px; }
-      .button-group.radius.stack-for-small > *:last-child, .button-group.radius.stack-for-small > *:last-child > a, .button-group.radius.stack-for-small > *:last-child > button, .button-group.radius.stack-for-small > *:last-child > .button {
+      .button-group.radius.stack-for-small > *:last-child,
+      .button-group.radius.stack-for-small > *:last-child > a,
+      .button-group.radius.stack-for-small > *:last-child > button,
+      .button-group.radius.stack-for-small > *:last-child > .button {
         -webkit-bottom-left-radius: 3px;
         -webkit-bottom-right-radius: 3px;
         border-bottom-left-radius: 3px;
@@ -2029,12 +1817,18 @@ button::-moz-focus-inner {
     .button-group.round > * > button,
     .button-group.round > * > .button {
       border-radius: 0; }
-    .button-group.round > *:first-child, .button-group.round > *:first-child > a, .button-group.round > *:first-child > button, .button-group.round > *:first-child > .button {
+    .button-group.round > *:first-child,
+    .button-group.round > *:first-child > a,
+    .button-group.round > *:first-child > button,
+    .button-group.round > *:first-child > .button {
       -webkit-border-bottom-left-radius: 1000px;
       -webkit-border-top-left-radius: 1000px;
       border-bottom-left-radius: 1000px;
       border-top-left-radius: 1000px; }
-    .button-group.round > *:last-child, .button-group.round > *:last-child > a, .button-group.round > *:last-child > button, .button-group.round > *:last-child > .button {
+    .button-group.round > *:last-child,
+    .button-group.round > *:last-child > a,
+    .button-group.round > *:last-child > button,
+    .button-group.round > *:last-child > .button {
       -webkit-border-bottom-right-radius: 1000px;
       -webkit-border-top-right-radius: 1000px;
       border-bottom-right-radius: 1000px;
@@ -2062,12 +1856,18 @@ button::-moz-focus-inner {
     .button-group.round.stack > * > button,
     .button-group.round.stack > * > .button {
       border-radius: 0; }
-    .button-group.round.stack > *:first-child, .button-group.round.stack > *:first-child > a, .button-group.round.stack > *:first-child > button, .button-group.round.stack > *:first-child > .button {
+    .button-group.round.stack > *:first-child,
+    .button-group.round.stack > *:first-child > a,
+    .button-group.round.stack > *:first-child > button,
+    .button-group.round.stack > *:first-child > .button {
       -webkit-top-left-radius: 1rem;
       -webkit-top-right-radius: 1rem;
       border-top-left-radius: 1rem;
       border-top-right-radius: 1rem; }
-    .button-group.round.stack > *:last-child, .button-group.round.stack > *:last-child > a, .button-group.round.stack > *:last-child > button, .button-group.round.stack > *:last-child > .button {
+    .button-group.round.stack > *:last-child,
+    .button-group.round.stack > *:last-child > a,
+    .button-group.round.stack > *:last-child > button,
+    .button-group.round.stack > *:last-child > .button {
       -webkit-bottom-left-radius: 1rem;
       -webkit-bottom-right-radius: 1rem;
       border-bottom-left-radius: 1rem;
@@ -2086,12 +1886,18 @@ button::-moz-focus-inner {
       .button-group.round.stack-for-small > * > button,
       .button-group.round.stack-for-small > * > .button {
         border-radius: 0; }
-      .button-group.round.stack-for-small > *:first-child, .button-group.round.stack-for-small > *:first-child > a, .button-group.round.stack-for-small > *:first-child > button, .button-group.round.stack-for-small > *:first-child > .button {
+      .button-group.round.stack-for-small > *:first-child,
+      .button-group.round.stack-for-small > *:first-child > a,
+      .button-group.round.stack-for-small > *:first-child > button,
+      .button-group.round.stack-for-small > *:first-child > .button {
         -webkit-border-bottom-left-radius: 1000px;
         -webkit-border-top-left-radius: 1000px;
         border-bottom-left-radius: 1000px;
         border-top-left-radius: 1000px; }
-      .button-group.round.stack-for-small > *:last-child, .button-group.round.stack-for-small > *:last-child > a, .button-group.round.stack-for-small > *:last-child > button, .button-group.round.stack-for-small > *:last-child > .button {
+      .button-group.round.stack-for-small > *:last-child,
+      .button-group.round.stack-for-small > *:last-child > a,
+      .button-group.round.stack-for-small > *:last-child > button,
+      .button-group.round.stack-for-small > *:last-child > .button {
         -webkit-border-bottom-right-radius: 1000px;
         -webkit-border-top-right-radius: 1000px;
         border-bottom-right-radius: 1000px;
@@ -2120,12 +1926,18 @@ button::-moz-focus-inner {
       .button-group.round.stack-for-small > * > button,
       .button-group.round.stack-for-small > * > .button {
         border-radius: 0; }
-      .button-group.round.stack-for-small > *:first-child, .button-group.round.stack-for-small > *:first-child > a, .button-group.round.stack-for-small > *:first-child > button, .button-group.round.stack-for-small > *:first-child > .button {
+      .button-group.round.stack-for-small > *:first-child,
+      .button-group.round.stack-for-small > *:first-child > a,
+      .button-group.round.stack-for-small > *:first-child > button,
+      .button-group.round.stack-for-small > *:first-child > .button {
         -webkit-top-left-radius: 1rem;
         -webkit-top-right-radius: 1rem;
         border-top-left-radius: 1rem;
         border-top-right-radius: 1rem; }
-      .button-group.round.stack-for-small > *:last-child, .button-group.round.stack-for-small > *:last-child > a, .button-group.round.stack-for-small > *:last-child > button, .button-group.round.stack-for-small > *:last-child > .button {
+      .button-group.round.stack-for-small > *:last-child,
+      .button-group.round.stack-for-small > *:last-child > a,
+      .button-group.round.stack-for-small > *:last-child > button,
+      .button-group.round.stack-for-small > *:last-child > .button {
         -webkit-bottom-left-radius: 1rem;
         -webkit-bottom-right-radius: 1rem;
         border-bottom-left-radius: 1rem;
@@ -2134,8 +1946,10 @@ button::-moz-focus-inner {
 .button-bar:before, .button-bar:after {
   content: " ";
   display: table; }
+
 .button-bar:after {
   clear: both; }
+
 .button-bar .button-group {
   float: left;
   margin-right: 0.625rem; }
@@ -2250,24 +2064,20 @@ button::-moz-focus-inner {
       .clearing-main-prev > span:hover,
       .clearing-main-next > span:hover {
         opacity: .8; }
-
   .clearing-main-prev {
     left: 0; }
     .clearing-main-prev > span {
       left: 5px;
       border-color: transparent;
       border-right-color: #CCCCCC; }
-
   .clearing-main-next {
     right: 0; }
     .clearing-main-next > span {
       border-color: transparent;
       border-left-color: #CCCCCC; }
-
   .clearing-main-prev.disabled,
   .clearing-main-next.disabled {
     opacity: .3; }
-
   .clearing-assembled .clearing-container .carousel {
     background: rgba(51, 51, 51, 0.8);
     height: 120px;
@@ -2309,13 +2119,13 @@ button::-moz-focus-inner {
     background: #333333;
     height: 85%;
     overflow: hidden; }
-
   .clearing-close {
     padding-left: 0;
     padding-top: 0;
     position: absolute;
     top: 10px;
     right: 20px; } }
+
 /* Foundation Dropdowns */
 .f-dropdown {
   display: none;
@@ -2646,6 +2456,7 @@ form .row .row {
       -webkit-border-top-right-radius: 0;
       border-bottom-right-radius: 0;
       border-top-right-radius: 0; }
+
 form .row input.column,
 form .row input.columns,
 form .row textarea.column,
@@ -2780,7 +2591,23 @@ input:not([type]), input[type="text"], input[type="password"], input[type="date"
   input:not([type]):disabled, input[type="text"]:disabled, input[type="password"]:disabled, input[type="date"]:disabled, input[type="datetime"]:disabled, input[type="datetime-local"]:disabled, input[type="month"]:disabled, input[type="week"]:disabled, input[type="email"]:disabled, input[type="number"]:disabled, input[type="search"]:disabled, input[type="tel"]:disabled, input[type="time"]:disabled, input[type="url"]:disabled, input[type="color"]:disabled, textarea:disabled {
     background-color: #DDDDDD;
     cursor: default; }
-  input:not([type])[disabled], input:not([type])[readonly], fieldset[disabled] input:not([type]), input[type="text"][disabled], input[type="text"][readonly], fieldset[disabled] input[type="text"], input[type="password"][disabled], input[type="password"][readonly], fieldset[disabled] input[type="password"], input[type="date"][disabled], input[type="date"][readonly], fieldset[disabled] input[type="date"], input[type="datetime"][disabled], input[type="datetime"][readonly], fieldset[disabled] input[type="datetime"], input[type="datetime-local"][disabled], input[type="datetime-local"][readonly], fieldset[disabled] input[type="datetime-local"], input[type="month"][disabled], input[type="month"][readonly], fieldset[disabled] input[type="month"], input[type="week"][disabled], input[type="week"][readonly], fieldset[disabled] input[type="week"], input[type="email"][disabled], input[type="email"][readonly], fieldset[disabled] input[type="email"], input[type="number"][disabled], input[type="number"][readonly], fieldset[disabled] input[type="number"], input[type="search"][disabled], input[type="search"][readonly], fieldset[disabled] input[type="search"], input[type="tel"][disabled], input[type="tel"][readonly], fieldset[disabled] input[type="tel"], input[type="time"][disabled], input[type="time"][readonly], fieldset[disabled] input[type="time"], input[type="url"][disabled], input[type="url"][readonly], fieldset[disabled] input[type="url"], input[type="color"][disabled], input[type="color"][readonly], fieldset[disabled] input[type="color"], textarea[disabled], textarea[readonly], fieldset[disabled] textarea {
+  input:not([type])[disabled], input:not([type])[readonly],
+  fieldset[disabled] input:not([type]), input[type="text"][disabled], input[type="text"][readonly],
+  fieldset[disabled] input[type="text"], input[type="password"][disabled], input[type="password"][readonly],
+  fieldset[disabled] input[type="password"], input[type="date"][disabled], input[type="date"][readonly],
+  fieldset[disabled] input[type="date"], input[type="datetime"][disabled], input[type="datetime"][readonly],
+  fieldset[disabled] input[type="datetime"], input[type="datetime-local"][disabled], input[type="datetime-local"][readonly],
+  fieldset[disabled] input[type="datetime-local"], input[type="month"][disabled], input[type="month"][readonly],
+  fieldset[disabled] input[type="month"], input[type="week"][disabled], input[type="week"][readonly],
+  fieldset[disabled] input[type="week"], input[type="email"][disabled], input[type="email"][readonly],
+  fieldset[disabled] input[type="email"], input[type="number"][disabled], input[type="number"][readonly],
+  fieldset[disabled] input[type="number"], input[type="search"][disabled], input[type="search"][readonly],
+  fieldset[disabled] input[type="search"], input[type="tel"][disabled], input[type="tel"][readonly],
+  fieldset[disabled] input[type="tel"], input[type="time"][disabled], input[type="time"][readonly],
+  fieldset[disabled] input[type="time"], input[type="url"][disabled], input[type="url"][readonly],
+  fieldset[disabled] input[type="url"], input[type="color"][disabled], input[type="color"][readonly],
+  fieldset[disabled] input[type="color"], textarea[disabled], textarea[readonly],
+  fieldset[disabled] textarea {
     background-color: #DDDDDD;
     cursor: default; }
   input:not([type]).radius, input[type="text"].radius, input[type="password"].radius, input[type="date"].radius, input[type="datetime"].radius, input[type="datetime-local"].radius, input[type="month"].radius, input[type="week"].radius, input[type="email"].radius, input[type="number"].radius, input[type="search"].radius, input[type="tel"].radius, input[type="time"].radius, input[type="url"].radius, input[type="color"].radius, textarea.radius {
@@ -2795,12 +2622,14 @@ form .row .prefix-radius.row.collapse button {
   -webkit-border-top-right-radius: 3px;
   border-bottom-right-radius: 3px;
   border-top-right-radius: 3px; }
+
 form .row .prefix-radius.row.collapse .prefix {
   border-radius: 0;
   -webkit-border-bottom-left-radius: 3px;
   -webkit-border-top-left-radius: 3px;
   border-bottom-left-radius: 3px;
   border-top-left-radius: 3px; }
+
 form .row .postfix-radius.row.collapse input,
 form .row .postfix-radius.row.collapse textarea,
 form .row .postfix-radius.row.collapse select,
@@ -2810,12 +2639,14 @@ form .row .postfix-radius.row.collapse button {
   -webkit-border-top-left-radius: 3px;
   border-bottom-left-radius: 3px;
   border-top-left-radius: 3px; }
+
 form .row .postfix-radius.row.collapse .postfix {
   border-radius: 0;
   -webkit-border-bottom-right-radius: 3px;
   -webkit-border-top-right-radius: 3px;
   border-bottom-right-radius: 3px;
   border-top-right-radius: 3px; }
+
 form .row .prefix-round.row.collapse input,
 form .row .prefix-round.row.collapse textarea,
 form .row .prefix-round.row.collapse select,
@@ -2825,12 +2656,14 @@ form .row .prefix-round.row.collapse button {
   -webkit-border-top-right-radius: 1000px;
   border-bottom-right-radius: 1000px;
   border-top-right-radius: 1000px; }
+
 form .row .prefix-round.row.collapse .prefix {
   border-radius: 0;
   -webkit-border-bottom-left-radius: 1000px;
   -webkit-border-top-left-radius: 1000px;
   border-bottom-left-radius: 1000px;
   border-top-left-radius: 1000px; }
+
 form .row .postfix-round.row.collapse input,
 form .row .postfix-round.row.collapse textarea,
 form .row .postfix-round.row.collapse select,
@@ -2840,6 +2673,7 @@ form .row .postfix-round.row.collapse button {
   -webkit-border-top-left-radius: 1000px;
   border-bottom-left-radius: 1000px;
   border-top-left-radius: 1000px; }
+
 form .row .postfix-round.row.collapse .postfix {
   border-radius: 0;
   -webkit-border-bottom-right-radius: 1000px;
@@ -2898,7 +2732,7 @@ select {
   select.radius {
     border-radius: 3px; }
   select:focus {
-    background-color: #f3f3f3;
+    background-color: #f3f2f2;
     border-color: #999999; }
   select:disabled {
     background-color: #DDDDDD;
@@ -2948,6 +2782,7 @@ fieldset {
   padding: 0.375rem 0.5625rem 0.5625rem;
   background: #f04124;
   color: #FFFFFF; }
+
 [data-abide] span.error, [data-abide] small.error {
   display: none; }
 
@@ -2966,12 +2801,15 @@ span.error, small.error {
 .error textarea,
 .error select {
   margin-bottom: 0; }
+
 .error input[type="checkbox"],
 .error input[type="radio"] {
   margin-bottom: 1rem; }
+
 .error label,
 .error label.error {
   color: #f04124; }
+
 .error small.error {
   display: block;
   font-size: 0.75rem;
@@ -2982,6 +2820,7 @@ span.error, small.error {
   padding: 0.375rem 0.5625rem 0.5625rem;
   background: #f04124;
   color: #FFFFFF; }
+
 .error > label > small {
   background: transparent;
   color: #95a34d;
@@ -2991,6 +2830,7 @@ span.error, small.error {
   margin: 0;
   padding: 0;
   text-transform: capitalize; }
+
 .error span.error-message {
   display: block; }
 
@@ -3165,71 +3005,98 @@ label.error {
 
 .icon-bar.two-up .item {
   width: 50%; }
+
 .icon-bar.two-up.vertical .item, .icon-bar.two-up.small-vertical .item {
   width: auto; }
+
 @media only screen and (min-width: 40.0625em) {
   .icon-bar.two-up.medium-vertical .item {
     width: auto; } }
+
 @media only screen and (min-width: 64.0625em) {
   .icon-bar.two-up.large-vertical .item {
     width: auto; } }
+
 .icon-bar.three-up .item {
   width: 33.3333%; }
+
 .icon-bar.three-up.vertical .item, .icon-bar.three-up.small-vertical .item {
   width: auto; }
+
 @media only screen and (min-width: 40.0625em) {
   .icon-bar.three-up.medium-vertical .item {
     width: auto; } }
+
 @media only screen and (min-width: 64.0625em) {
   .icon-bar.three-up.large-vertical .item {
     width: auto; } }
+
 .icon-bar.four-up .item {
   width: 25%; }
+
 .icon-bar.four-up.vertical .item, .icon-bar.four-up.small-vertical .item {
   width: auto; }
+
 @media only screen and (min-width: 40.0625em) {
   .icon-bar.four-up.medium-vertical .item {
     width: auto; } }
+
 @media only screen and (min-width: 64.0625em) {
   .icon-bar.four-up.large-vertical .item {
     width: auto; } }
+
 .icon-bar.five-up .item {
   width: 20%; }
+
 .icon-bar.five-up.vertical .item, .icon-bar.five-up.small-vertical .item {
   width: auto; }
+
 @media only screen and (min-width: 40.0625em) {
   .icon-bar.five-up.medium-vertical .item {
     width: auto; } }
+
 @media only screen and (min-width: 64.0625em) {
   .icon-bar.five-up.large-vertical .item {
     width: auto; } }
+
 .icon-bar.six-up .item {
   width: 16.66667%; }
+
 .icon-bar.six-up.vertical .item, .icon-bar.six-up.small-vertical .item {
   width: auto; }
+
 @media only screen and (min-width: 40.0625em) {
   .icon-bar.six-up.medium-vertical .item {
     width: auto; } }
+
 @media only screen and (min-width: 64.0625em) {
   .icon-bar.six-up.large-vertical .item {
     width: auto; } }
+
 .icon-bar.seven-up .item {
   width: 14.28571%; }
+
 .icon-bar.seven-up.vertical .item, .icon-bar.seven-up.small-vertical .item {
   width: auto; }
+
 @media only screen and (min-width: 40.0625em) {
   .icon-bar.seven-up.medium-vertical .item {
     width: auto; } }
+
 @media only screen and (min-width: 64.0625em) {
   .icon-bar.seven-up.large-vertical .item {
     width: auto; } }
+
 .icon-bar.eight-up .item {
   width: 12.5%; }
+
 .icon-bar.eight-up.vertical .item, .icon-bar.eight-up.small-vertical .item {
   width: auto; }
+
 @media only screen and (min-width: 40.0625em) {
   .icon-bar.eight-up.medium-vertical .item {
     width: auto; } }
+
 @media only screen and (min-width: 64.0625em) {
   .icon-bar.eight-up.large-vertical .item {
     width: auto; } }
@@ -3403,6 +3270,7 @@ label.error {
       left: -20px;
       right: auto;
       top: 22px; } }
+
 .keystroke,
 kbd {
   background-color: #ededed;
@@ -3469,6 +3337,7 @@ kbd {
   to {
     -webkit-transform: rotate(360deg);
     transform: rotate(360deg); } }
+
 @keyframes rotate {
   from {
     -webkit-transform: rotate(0deg);
@@ -3480,6 +3349,7 @@ kbd {
     -moz-transform: rotate(360deg);
     -ms-transform: rotate(360deg);
     transform: rotate(360deg); } }
+
 /* Orbit Graceful Loading */
 .slideshow-wrapper {
   position: relative; }
@@ -3669,6 +3539,7 @@ kbd {
 .touch .orbit-container .orbit-prev,
 .touch .orbit-container .orbit-next {
   display: none; }
+
 .touch .orbit-bullets {
   display: none; }
 
@@ -3678,6 +3549,7 @@ kbd {
     display: inherit; }
   .touch .orbit-bullets {
     display: block; } }
+
 @media only screen and (max-width: 40em) {
   .orbit-stack-on-small .orbit-slides-container {
     height: auto !important; }
@@ -3687,15 +3559,13 @@ kbd {
     position: relative; }
   .orbit-stack-on-small .orbit-slide-number {
     display: none; }
-
   .orbit-timer {
     display: none; }
-
   .orbit-next, .orbit-prev {
     display: none; }
-
   .orbit-bullets {
     display: none; } }
+
 ul.pagination {
   display: block;
   margin-left: -0.3125rem;
@@ -3716,14 +3586,18 @@ ul.pagination {
       line-height: inherit;
       padding: 0.0625rem 0.625rem 0.0625rem; }
     ul.pagination li:hover a,
-    ul.pagination li a:focus, ul.pagination li:hover button,
+    ul.pagination li a:focus,
+    ul.pagination li:hover button,
     ul.pagination li button:focus {
-      background: #e6e6e6; }
+      background: #e6e5e5; }
     ul.pagination li.unavailable a, ul.pagination li.unavailable button {
       cursor: default;
       color: #999999;
       pointer-events: none; }
-    ul.pagination li.unavailable:hover a, ul.pagination li.unavailable a:focus, ul.pagination li.unavailable:hover button, ul.pagination li.unavailable button:focus {
+    ul.pagination li.unavailable:hover a,
+    ul.pagination li.unavailable a:focus,
+    ul.pagination li.unavailable:hover button,
+    ul.pagination li.unavailable button:focus {
       background: transparent; }
     ul.pagination li.current a, ul.pagination li.current button {
       background: #859145;
@@ -4377,8 +4251,8 @@ table {
     background: #F5F5F5; }
     table thead tr th,
     table thead tr td,
-    table thead tr .backgrid th,
-    .backgrid table thead tr th {
+    table thead tr .backgrid th, .backgrid
+    table thead tr th {
       color: #222222;
       font-size: 0.875rem;
       font-weight: bold;
@@ -4387,16 +4261,16 @@ table {
     background: #F5F5F5; }
     table tfoot tr th,
     table tfoot tr td,
-    table tfoot tr .backgrid th,
-    .backgrid table tfoot tr th {
+    table tfoot tr .backgrid th, .backgrid
+    table tfoot tr th {
       color: #222222;
       font-size: 0.875rem;
       font-weight: bold;
       padding: 0.5rem 0.625rem 0.625rem; }
   table tr th,
   table tr td,
-  table tr .backgrid th,
-  .backgrid table tr th {
+  table tr .backgrid th, .backgrid
+  table tr th {
     color: #222222;
     font-size: 0.875rem;
     padding: 0.5625rem 0.625rem;
@@ -4406,15 +4280,15 @@ table {
   table thead tr th,
   table tfoot tr th,
   table tfoot tr td,
-  table tfoot tr .backgrid th,
-  .backgrid table tfoot tr th,
+  table tfoot tr .backgrid th, .backgrid
+  table tfoot tr th,
   table tbody tr th,
   table tbody tr td,
-  table tbody tr .backgrid th,
-  .backgrid table tbody tr th,
+  table tbody tr .backgrid th, .backgrid
+  table tbody tr th,
   table tr td,
-  table tr .backgrid th,
-  .backgrid table tr th {
+  table tr .backgrid th, .backgrid
+  table tr th {
     display: table-cell;
     line-height: 1.125rem; }
 
@@ -4496,13 +4370,13 @@ table {
     margin-bottom: 1.25rem !important;
     max-width: 20%;
     width: 20%; }
-
   .tabs-content.vertical {
     float: left;
     margin-left: -1px;
     max-width: 80%;
     padding-left: 1rem;
     width: 80%; } }
+
 .no-js .tabs-content > .content {
   display: block;
   float: none; }
@@ -4596,6 +4470,7 @@ table {
     margin-top: -5px;
     right: auto;
     top: 50%; } }
+
 meta.foundation-mq-topbar {
   font-family: "/only screen and (min-width:40.0625em)/";
   width: 40.0625em; }
@@ -4739,7 +4614,7 @@ meta.foundation-mq-topbar {
     width: 100%; }
   .top-bar-section .divider,
   .top-bar-section [role="separator"] {
-    border-top: solid 1px #1a1a1a;
+    border-top: solid 1px #1a1919;
     clear: both;
     height: 1px;
     width: 100%; }
@@ -4978,12 +4853,10 @@ meta.foundation-mq-topbar {
       top: 0.53125rem; }
     .top-bar.expanded {
       background: #333333; }
-
   .contain-to-grid .top-bar {
     margin: 0 auto;
     margin-bottom: 0;
     max-width: 100%; }
-
   .top-bar-section {
     transition: none 0 0;
     left: 0 !important; }
@@ -5102,7 +4975,6 @@ meta.foundation-mq-topbar {
       left: 0; }
       .top-bar-section .left li .dropdown li .dropdown {
         left: 100%; }
-
   .no-js .top-bar-section ul li:hover > a {
     background-color: #555555;
     background: #222222;
@@ -5126,6 +4998,7 @@ meta.foundation-mq-topbar {
     clip: auto;
     display: block;
     position: absolute !important; } }
+
 .text-left {
   text-align: left !important; }
 
@@ -5141,123 +5014,103 @@ meta.foundation-mq-topbar {
 @media only screen and (max-width: 40em) {
   .small-only-text-left {
     text-align: left !important; }
-
   .small-only-text-right {
     text-align: right !important; }
-
   .small-only-text-center {
     text-align: center !important; }
-
   .small-only-text-justify {
     text-align: justify !important; } }
+
 @media only screen {
   .small-text-left {
     text-align: left !important; }
-
   .small-text-right {
     text-align: right !important; }
-
   .small-text-center {
     text-align: center !important; }
-
   .small-text-justify {
     text-align: justify !important; } }
+
 @media only screen and (min-width: 40.0625em) and (max-width: 64em) {
   .medium-only-text-left {
     text-align: left !important; }
-
   .medium-only-text-right {
     text-align: right !important; }
-
   .medium-only-text-center {
     text-align: center !important; }
-
   .medium-only-text-justify {
     text-align: justify !important; } }
+
 @media only screen and (min-width: 40.0625em) {
   .medium-text-left {
     text-align: left !important; }
-
   .medium-text-right {
     text-align: right !important; }
-
   .medium-text-center {
     text-align: center !important; }
-
   .medium-text-justify {
     text-align: justify !important; } }
+
 @media only screen and (min-width: 64.0625em) and (max-width: 90em) {
   .large-only-text-left {
     text-align: left !important; }
-
   .large-only-text-right {
     text-align: right !important; }
-
   .large-only-text-center {
     text-align: center !important; }
-
   .large-only-text-justify {
     text-align: justify !important; } }
+
 @media only screen and (min-width: 64.0625em) {
   .large-text-left {
     text-align: left !important; }
-
   .large-text-right {
     text-align: right !important; }
-
   .large-text-center {
     text-align: center !important; }
-
   .large-text-justify {
     text-align: justify !important; } }
+
 @media only screen and (min-width: 90.0625em) and (max-width: 120em) {
   .xlarge-only-text-left {
     text-align: left !important; }
-
   .xlarge-only-text-right {
     text-align: right !important; }
-
   .xlarge-only-text-center {
     text-align: center !important; }
-
   .xlarge-only-text-justify {
     text-align: justify !important; } }
+
 @media only screen and (min-width: 90.0625em) {
   .xlarge-text-left {
     text-align: left !important; }
-
   .xlarge-text-right {
     text-align: right !important; }
-
   .xlarge-text-center {
     text-align: center !important; }
-
   .xlarge-text-justify {
     text-align: justify !important; } }
+
 @media only screen and (min-width: 120.0625em) and (max-width: 6249999.9375em) {
   .xxlarge-only-text-left {
     text-align: left !important; }
-
   .xxlarge-only-text-right {
     text-align: right !important; }
-
   .xxlarge-only-text-center {
     text-align: center !important; }
-
   .xxlarge-only-text-justify {
     text-align: justify !important; } }
+
 @media only screen and (min-width: 120.0625em) {
   .xxlarge-text-left {
     text-align: left !important; }
-
   .xxlarge-text-right {
     text-align: right !important; }
-
   .xxlarge-text-center {
     text-align: center !important; }
-
   .xxlarge-text-justify {
     text-align: justify !important; } }
+
 /* Typography resets */
 div,
 dl,
@@ -5398,14 +5251,18 @@ ul li ul,
 ul li ol {
   margin-left: 1.25rem;
   margin-bottom: 0; }
+
 ul.square li ul, ul.circle li ul, ul.disc li ul {
   list-style: inherit; }
+
 ul.square {
   list-style-type: square;
   margin-left: 1.1rem; }
+
 ul.circle {
   list-style-type: circle;
   margin-left: 1.1rem; }
+
 ul.disc {
   list-style-type: disc;
   margin-left: 1.1rem; }
@@ -5431,6 +5288,7 @@ ol {
 dl dt {
   margin-bottom: 0.3rem;
   font-weight: bold; }
+
 dl dd {
   margin-bottom: 0.75rem; }
 
@@ -5482,6 +5340,7 @@ blockquote p {
 
 .vevent .summary {
   font-weight: bold; }
+
 .vevent abbr {
   cursor: default;
   text-decoration: none;
@@ -5492,30 +5351,25 @@ blockquote p {
 @media only screen and (min-width: 40.0625em) {
   h1, h2, h3, h4, h5, h6 {
     line-height: 1.4; }
-
   h1 {
     font-size: 2.75rem; }
-
   h2 {
     font-size: 2.3125rem; }
-
   h3 {
     font-size: 1.6875rem; }
-
   h4 {
     font-size: 1.4375rem; }
-
   h5 {
     font-size: 1.125rem; }
-
   h6 {
     font-size: 1rem; } }
+
 /*
- * Print styles.
- *
- * Inlined to avoid required HTTP connection: www.phpied.com/delay-loading-your-print-css/
- * Credit to Paul Irish and HTML5 Boilerplate (html5boilerplate.com)
-*/
+       * Print styles.
+       *
+       * Inlined to avoid required HTTP connection: www.phpied.com/delay-loading-your-print-css/
+       * Credit to Paul Irish and HTML5 Boilerplate (html5boilerplate.com)
+      */
 @media print {
   * {
     background: transparent !important;
@@ -5523,38 +5377,29 @@ blockquote p {
     /* Black prints faster: h5bp.com/s */
     box-shadow: none !important;
     text-shadow: none !important; }
-
   a,
   a:visited {
     text-decoration: underline; }
-
   a[href]:after {
     content: " (" attr(href) ")"; }
-
   abbr[title]:after {
     content: " (" attr(title) ")"; }
-
   .ir a:after,
   a[href^="javascript:"]:after,
   a[href^="#"]:after {
     content: ""; }
-
   pre,
   blockquote {
     border: 1px solid #999999;
     page-break-inside: avoid; }
-
   thead {
     display: table-header-group;
     /* h5bp.com/t */ }
-
   tr,
   img {
     page-break-inside: avoid; }
-
   img {
     max-width: 100% !important; }
-
   @page {
     margin: 0.34in; }
   p,
@@ -5562,10 +5407,10 @@ blockquote p {
   h3 {
     orphans: 3;
     widows: 3; }
-
   h2,
   h3 {
     page-break-after: avoid; } }
+
 .off-canvas-wrap {
   -webkit-backface-visibility: hidden;
   position: relative;
@@ -5609,7 +5454,7 @@ blockquote p {
   position: absolute;
   top: 0;
   width: 2.8125rem;
-  border-right: solid 1px #1a1a1a;
+  border-right: solid 1px #1a1919;
   left: 0; }
 
 .right-small {
@@ -5617,7 +5462,7 @@ blockquote p {
   position: absolute;
   top: 0;
   width: 2.8125rem;
-  border-left: solid 1px #1a1a1a;
+  border-left: solid 1px #1a1919;
   right: 0; }
 
 .tab-bar-section {
@@ -5660,7 +5505,7 @@ blockquote p {
     box-shadow: 0 0 0 1px #FFFFFF, 0 7px 0 1px #FFFFFF, 0 14px 0 1px #FFFFFF;
     width: 1rem; }
   .tab-bar .menu-icon span:hover:after {
-    box-shadow: 0 0 0 1px #b3b3b3, 0 7px 0 1px #b3b3b3, 0 14px 0 1px #b3b3b3; }
+    box-shadow: 0 0 0 1px #b3b2b2, 0 7px 0 1px #b3b2b2, 0 14px 0 1px #b3b2b2; }
 
 .left-off-canvas-menu {
   -webkit-backface-visibility: hidden;
@@ -5775,7 +5620,7 @@ ul.off-canvas-list {
     border-bottom: 1px solid #262626;
     color: rgba(255, 255, 255, 0.7);
     display: block;
-    padding: 0.66667rem;
+    padding: 0.6666666667rem;
     transition: background 300ms ease; }
     ul.off-canvas-list li a:hover {
       background: #242424; }
@@ -5788,6 +5633,7 @@ ul.off-canvas-list {
   -ms-transform: translate(15.625rem, 0);
   -o-transform: translate3d(15.625rem, 0, 0);
   transform: translate3d(15.625rem, 0, 0); }
+
 .move-right .exit-off-canvas {
   -webkit-backface-visibility: hidden;
   box-shadow: -4px 0 4px rgba(0, 0, 0, 0.5), 4px 0 4px rgba(0, 0, 0, 0.5);
@@ -5812,6 +5658,7 @@ ul.off-canvas-list {
   -ms-transform: translate(-15.625rem, 0);
   -o-transform: translate3d(-15.625rem, 0, 0);
   transform: translate3d(-15.625rem, 0, 0); }
+
 .move-left .exit-off-canvas {
   -webkit-backface-visibility: hidden;
   box-shadow: -4px 0 4px rgba(0, 0, 0, 0.5), 4px 0 4px rgba(0, 0, 0, 0.5);
@@ -5836,6 +5683,7 @@ ul.off-canvas-list {
   -ms-transform: translate(0, -18.75rem);
   -o-transform: translate3d(0, -18.75rem, 0);
   transform: translate3d(0, -18.75rem, 0); }
+
 .move-top .exit-off-canvas {
   -webkit-backface-visibility: hidden;
   box-shadow: -4px 0 4px rgba(0, 0, 0, 0.5), 4px 0 4px rgba(0, 0, 0, 0.5);
@@ -5860,6 +5708,7 @@ ul.off-canvas-list {
   -ms-transform: translate(0, 18.75rem);
   -o-transform: translate3d(0, 18.75rem, 0);
   transform: translate3d(0, 18.75rem, 0); }
+
 .move-bottom .exit-off-canvas {
   -webkit-backface-visibility: hidden;
   box-shadow: -4px 0 4px rgba(0, 0, 0, 0.5), 4px 0 4px rgba(0, 0, 0, 0.5);
@@ -5886,6 +5735,7 @@ ul.off-canvas-list {
   -o-transform: none;
   transform: none;
   z-index: 1003; }
+
 .offcanvas-overlap .exit-off-canvas {
   -webkit-backface-visibility: hidden;
   box-shadow: -4px 0 4px rgba(0, 0, 0, 0.5), 4px 0 4px rgba(0, 0, 0, 0.5);
@@ -5911,6 +5761,7 @@ ul.off-canvas-list {
   -o-transform: none;
   transform: none;
   z-index: 1003; }
+
 .offcanvas-overlap-left .exit-off-canvas {
   -webkit-backface-visibility: hidden;
   box-shadow: -4px 0 4px rgba(0, 0, 0, 0.5), 4px 0 4px rgba(0, 0, 0, 0.5);
@@ -5936,6 +5787,7 @@ ul.off-canvas-list {
   -o-transform: none;
   transform: none;
   z-index: 1003; }
+
 .offcanvas-overlap-right .exit-off-canvas {
   -webkit-backface-visibility: hidden;
   box-shadow: -4px 0 4px rgba(0, 0, 0, 0.5), 4px 0 4px rgba(0, 0, 0, 0.5);
@@ -5961,6 +5813,7 @@ ul.off-canvas-list {
   -o-transform: none;
   transform: none;
   z-index: 1003; }
+
 .offcanvas-overlap-top .exit-off-canvas {
   -webkit-backface-visibility: hidden;
   box-shadow: -4px 0 4px rgba(0, 0, 0, 0.5), 4px 0 4px rgba(0, 0, 0, 0.5);
@@ -5986,6 +5839,7 @@ ul.off-canvas-list {
   -o-transform: none;
   transform: none;
   z-index: 1003; }
+
 .offcanvas-overlap-bottom .exit-off-canvas {
   -webkit-backface-visibility: hidden;
   box-shadow: -4px 0 4px rgba(0, 0, 0, 0.5), 4px 0 4px rgba(0, 0, 0, 0.5);
@@ -6006,18 +5860,25 @@ ul.off-canvas-list {
 
 .no-csstransforms .left-off-canvas-menu {
   left: -15.625rem; }
+
 .no-csstransforms .right-off-canvas-menu {
   right: -15.625rem; }
+
 .no-csstransforms .top-off-canvas-menu {
   top: -18.75rem; }
+
 .no-csstransforms .bottom-off-canvas-menu {
   bottom: -18.75rem; }
+
 .no-csstransforms .move-left > .inner-wrap {
   right: 15.625rem; }
+
 .no-csstransforms .move-right > .inner-wrap {
   left: 15.625rem; }
+
 .no-csstransforms .move-top > .inner-wrap {
   right: 18.75rem; }
+
 .no-csstransforms .move-bottom > .inner-wrap {
   left: 18.75rem; }
 
@@ -6233,182 +6094,147 @@ ul.off-canvas-list {
 @media only screen {
   .show-for-small-only, .show-for-small-up, .show-for-small, .show-for-small-down, .hide-for-medium-only, .hide-for-medium-up, .hide-for-medium, .show-for-medium-down, .hide-for-large-only, .hide-for-large-up, .hide-for-large, .show-for-large-down, .hide-for-xlarge-only, .hide-for-xlarge-up, .hide-for-xlarge, .show-for-xlarge-down, .hide-for-xxlarge-only, .hide-for-xxlarge-up, .hide-for-xxlarge, .show-for-xxlarge-down {
     display: inherit !important; }
-
   .hide-for-small-only, .hide-for-small-up, .hide-for-small, .hide-for-small-down, .show-for-medium-only, .show-for-medium-up, .show-for-medium, .hide-for-medium-down, .show-for-large-only, .show-for-large-up, .show-for-large, .hide-for-large-down, .show-for-xlarge-only, .show-for-xlarge-up, .show-for-xlarge, .hide-for-xlarge-down, .show-for-xxlarge-only, .show-for-xxlarge-up, .show-for-xxlarge, .hide-for-xxlarge-down {
     display: none !important; }
-
   .visible-for-small-only, .visible-for-small-up, .visible-for-small, .visible-for-small-down, .hidden-for-medium-only, .hidden-for-medium-up, .hidden-for-medium, .visible-for-medium-down, .hidden-for-large-only, .hidden-for-large-up, .hidden-for-large, .visible-for-large-down, .hidden-for-xlarge-only, .hidden-for-xlarge-up, .hidden-for-xlarge, .visible-for-xlarge-down, .hidden-for-xxlarge-only, .hidden-for-xxlarge-up, .hidden-for-xxlarge, .visible-for-xxlarge-down {
     position: static !important;
     height: auto;
     width: auto;
     overflow: visible;
     clip: auto; }
-
   .hidden-for-small-only, .hidden-for-small-up, .hidden-for-small, .hidden-for-small-down, .visible-for-medium-only, .visible-for-medium-up, .visible-for-medium, .hidden-for-medium-down, .visible-for-large-only, .visible-for-large-up, .visible-for-large, .hidden-for-large-down, .visible-for-xlarge-only, .visible-for-xlarge-up, .visible-for-xlarge, .hidden-for-xlarge-down, .visible-for-xxlarge-only, .visible-for-xxlarge-up, .visible-for-xxlarge, .hidden-for-xxlarge-down {
     clip: rect(1px, 1px, 1px, 1px);
     height: 1px;
     overflow: hidden;
     position: absolute !important;
     width: 1px; }
-
   table.show-for-small-only, table.show-for-small-up, table.show-for-small, table.show-for-small-down, table.hide-for-medium-only, table.hide-for-medium-up, table.hide-for-medium, table.show-for-medium-down, table.hide-for-large-only, table.hide-for-large-up, table.hide-for-large, table.show-for-large-down, table.hide-for-xlarge-only, table.hide-for-xlarge-up, table.hide-for-xlarge, table.show-for-xlarge-down, table.hide-for-xxlarge-only, table.hide-for-xxlarge-up, table.hide-for-xxlarge, table.show-for-xxlarge-down {
     display: table !important; }
-
   thead.show-for-small-only, thead.show-for-small-up, thead.show-for-small, thead.show-for-small-down, thead.hide-for-medium-only, thead.hide-for-medium-up, thead.hide-for-medium, thead.show-for-medium-down, thead.hide-for-large-only, thead.hide-for-large-up, thead.hide-for-large, thead.show-for-large-down, thead.hide-for-xlarge-only, thead.hide-for-xlarge-up, thead.hide-for-xlarge, thead.show-for-xlarge-down, thead.hide-for-xxlarge-only, thead.hide-for-xxlarge-up, thead.hide-for-xxlarge, thead.show-for-xxlarge-down {
     display: table-header-group !important; }
-
   tbody.show-for-small-only, tbody.show-for-small-up, tbody.show-for-small, tbody.show-for-small-down, tbody.hide-for-medium-only, tbody.hide-for-medium-up, tbody.hide-for-medium, tbody.show-for-medium-down, tbody.hide-for-large-only, tbody.hide-for-large-up, tbody.hide-for-large, tbody.show-for-large-down, tbody.hide-for-xlarge-only, tbody.hide-for-xlarge-up, tbody.hide-for-xlarge, tbody.show-for-xlarge-down, tbody.hide-for-xxlarge-only, tbody.hide-for-xxlarge-up, tbody.hide-for-xxlarge, tbody.show-for-xxlarge-down {
     display: table-row-group !important; }
-
   tr.show-for-small-only, tr.show-for-small-up, tr.show-for-small, tr.show-for-small-down, tr.hide-for-medium-only, tr.hide-for-medium-up, tr.hide-for-medium, tr.show-for-medium-down, tr.hide-for-large-only, tr.hide-for-large-up, tr.hide-for-large, tr.show-for-large-down, tr.hide-for-xlarge-only, tr.hide-for-xlarge-up, tr.hide-for-xlarge, tr.show-for-xlarge-down, tr.hide-for-xxlarge-only, tr.hide-for-xxlarge-up, tr.hide-for-xxlarge, tr.show-for-xxlarge-down {
     display: table-row; }
-
   th.show-for-small-only, td.show-for-small-only, .backgrid th.show-for-small-only, th.show-for-small-up, td.show-for-small-up, .backgrid th.show-for-small-up, th.show-for-small, td.show-for-small, .backgrid th.show-for-small, th.show-for-small-down, td.show-for-small-down, .backgrid th.show-for-small-down, th.hide-for-medium-only, td.hide-for-medium-only, .backgrid th.hide-for-medium-only, th.hide-for-medium-up, td.hide-for-medium-up, .backgrid th.hide-for-medium-up, th.hide-for-medium, td.hide-for-medium, .backgrid th.hide-for-medium, th.show-for-medium-down, td.show-for-medium-down, .backgrid th.show-for-medium-down, th.hide-for-large-only, td.hide-for-large-only, .backgrid th.hide-for-large-only, th.hide-for-large-up, td.hide-for-large-up, .backgrid th.hide-for-large-up, th.hide-for-large, td.hide-for-large, .backgrid th.hide-for-large, th.show-for-large-down, td.show-for-large-down, .backgrid th.show-for-large-down, th.hide-for-xlarge-only, td.hide-for-xlarge-only, .backgrid th.hide-for-xlarge-only, th.hide-for-xlarge-up, td.hide-for-xlarge-up, .backgrid th.hide-for-xlarge-up, th.hide-for-xlarge, td.hide-for-xlarge, .backgrid th.hide-for-xlarge, th.show-for-xlarge-down, td.show-for-xlarge-down, .backgrid th.show-for-xlarge-down, th.hide-for-xxlarge-only, td.hide-for-xxlarge-only, .backgrid th.hide-for-xxlarge-only, th.hide-for-xxlarge-up, td.hide-for-xxlarge-up, .backgrid th.hide-for-xxlarge-up, th.hide-for-xxlarge, td.hide-for-xxlarge, .backgrid th.hide-for-xxlarge, th.show-for-xxlarge-down, td.show-for-xxlarge-down, .backgrid th.show-for-xxlarge-down {
     display: table-cell !important; } }
+
 /* medium displays */
 @media only screen and (min-width: 40.0625em) {
   .hide-for-small-only, .show-for-small-up, .hide-for-small, .hide-for-small-down, .show-for-medium-only, .show-for-medium-up, .show-for-medium, .show-for-medium-down, .hide-for-large-only, .hide-for-large-up, .hide-for-large, .show-for-large-down, .hide-for-xlarge-only, .hide-for-xlarge-up, .hide-for-xlarge, .show-for-xlarge-down, .hide-for-xxlarge-only, .hide-for-xxlarge-up, .hide-for-xxlarge, .show-for-xxlarge-down {
     display: inherit !important; }
-
   .show-for-small-only, .hide-for-small-up, .show-for-small, .show-for-small-down, .hide-for-medium-only, .hide-for-medium-up, .hide-for-medium, .hide-for-medium-down, .show-for-large-only, .show-for-large-up, .show-for-large, .hide-for-large-down, .show-for-xlarge-only, .show-for-xlarge-up, .show-for-xlarge, .hide-for-xlarge-down, .show-for-xxlarge-only, .show-for-xxlarge-up, .show-for-xxlarge, .hide-for-xxlarge-down {
     display: none !important; }
-
   .hidden-for-small-only, .visible-for-small-up, .hidden-for-small, .hidden-for-small-down, .visible-for-medium-only, .visible-for-medium-up, .visible-for-medium, .visible-for-medium-down, .hidden-for-large-only, .hidden-for-large-up, .hidden-for-large, .visible-for-large-down, .hidden-for-xlarge-only, .hidden-for-xlarge-up, .hidden-for-xlarge, .visible-for-xlarge-down, .hidden-for-xxlarge-only, .hidden-for-xxlarge-up, .hidden-for-xxlarge, .visible-for-xxlarge-down {
     position: static !important;
     height: auto;
     width: auto;
     overflow: visible;
     clip: auto; }
-
   .visible-for-small-only, .hidden-for-small-up, .visible-for-small, .visible-for-small-down, .hidden-for-medium-only, .hidden-for-medium-up, .hidden-for-medium, .hidden-for-medium-down, .visible-for-large-only, .visible-for-large-up, .visible-for-large, .hidden-for-large-down, .visible-for-xlarge-only, .visible-for-xlarge-up, .visible-for-xlarge, .hidden-for-xlarge-down, .visible-for-xxlarge-only, .visible-for-xxlarge-up, .visible-for-xxlarge, .hidden-for-xxlarge-down {
     clip: rect(1px, 1px, 1px, 1px);
     height: 1px;
     overflow: hidden;
     position: absolute !important;
     width: 1px; }
-
   table.hide-for-small-only, table.show-for-small-up, table.hide-for-small, table.hide-for-small-down, table.show-for-medium-only, table.show-for-medium-up, table.show-for-medium, table.show-for-medium-down, table.hide-for-large-only, table.hide-for-large-up, table.hide-for-large, table.show-for-large-down, table.hide-for-xlarge-only, table.hide-for-xlarge-up, table.hide-for-xlarge, table.show-for-xlarge-down, table.hide-for-xxlarge-only, table.hide-for-xxlarge-up, table.hide-for-xxlarge, table.show-for-xxlarge-down {
     display: table !important; }
-
   thead.hide-for-small-only, thead.show-for-small-up, thead.hide-for-small, thead.hide-for-small-down, thead.show-for-medium-only, thead.show-for-medium-up, thead.show-for-medium, thead.show-for-medium-down, thead.hide-for-large-only, thead.hide-for-large-up, thead.hide-for-large, thead.show-for-large-down, thead.hide-for-xlarge-only, thead.hide-for-xlarge-up, thead.hide-for-xlarge, thead.show-for-xlarge-down, thead.hide-for-xxlarge-only, thead.hide-for-xxlarge-up, thead.hide-for-xxlarge, thead.show-for-xxlarge-down {
     display: table-header-group !important; }
-
   tbody.hide-for-small-only, tbody.show-for-small-up, tbody.hide-for-small, tbody.hide-for-small-down, tbody.show-for-medium-only, tbody.show-for-medium-up, tbody.show-for-medium, tbody.show-for-medium-down, tbody.hide-for-large-only, tbody.hide-for-large-up, tbody.hide-for-large, tbody.show-for-large-down, tbody.hide-for-xlarge-only, tbody.hide-for-xlarge-up, tbody.hide-for-xlarge, tbody.show-for-xlarge-down, tbody.hide-for-xxlarge-only, tbody.hide-for-xxlarge-up, tbody.hide-for-xxlarge, tbody.show-for-xxlarge-down {
     display: table-row-group !important; }
-
   tr.hide-for-small-only, tr.show-for-small-up, tr.hide-for-small, tr.hide-for-small-down, tr.show-for-medium-only, tr.show-for-medium-up, tr.show-for-medium, tr.show-for-medium-down, tr.hide-for-large-only, tr.hide-for-large-up, tr.hide-for-large, tr.show-for-large-down, tr.hide-for-xlarge-only, tr.hide-for-xlarge-up, tr.hide-for-xlarge, tr.show-for-xlarge-down, tr.hide-for-xxlarge-only, tr.hide-for-xxlarge-up, tr.hide-for-xxlarge, tr.show-for-xxlarge-down {
     display: table-row; }
-
   th.hide-for-small-only, td.hide-for-small-only, .backgrid th.hide-for-small-only, th.show-for-small-up, td.show-for-small-up, .backgrid th.show-for-small-up, th.hide-for-small, td.hide-for-small, .backgrid th.hide-for-small, th.hide-for-small-down, td.hide-for-small-down, .backgrid th.hide-for-small-down, th.show-for-medium-only, td.show-for-medium-only, .backgrid th.show-for-medium-only, th.show-for-medium-up, td.show-for-medium-up, .backgrid th.show-for-medium-up, th.show-for-medium, td.show-for-medium, .backgrid th.show-for-medium, th.show-for-medium-down, td.show-for-medium-down, .backgrid th.show-for-medium-down, th.hide-for-large-only, td.hide-for-large-only, .backgrid th.hide-for-large-only, th.hide-for-large-up, td.hide-for-large-up, .backgrid th.hide-for-large-up, th.hide-for-large, td.hide-for-large, .backgrid th.hide-for-large, th.show-for-large-down, td.show-for-large-down, .backgrid th.show-for-large-down, th.hide-for-xlarge-only, td.hide-for-xlarge-only, .backgrid th.hide-for-xlarge-only, th.hide-for-xlarge-up, td.hide-for-xlarge-up, .backgrid th.hide-for-xlarge-up, th.hide-for-xlarge, td.hide-for-xlarge, .backgrid th.hide-for-xlarge, th.show-for-xlarge-down, td.show-for-xlarge-down, .backgrid th.show-for-xlarge-down, th.hide-for-xxlarge-only, td.hide-for-xxlarge-only, .backgrid th.hide-for-xxlarge-only, th.hide-for-xxlarge-up, td.hide-for-xxlarge-up, .backgrid th.hide-for-xxlarge-up, th.hide-for-xxlarge, td.hide-for-xxlarge, .backgrid th.hide-for-xxlarge, th.show-for-xxlarge-down, td.show-for-xxlarge-down, .backgrid th.show-for-xxlarge-down {
     display: table-cell !important; } }
+
 /* large displays */
 @media only screen and (min-width: 64.0625em) {
   .hide-for-small-only, .show-for-small-up, .hide-for-small, .hide-for-small-down, .hide-for-medium-only, .show-for-medium-up, .hide-for-medium, .hide-for-medium-down, .show-for-large-only, .show-for-large-up, .show-for-large, .show-for-large-down, .hide-for-xlarge-only, .hide-for-xlarge-up, .hide-for-xlarge, .show-for-xlarge-down, .hide-for-xxlarge-only, .hide-for-xxlarge-up, .hide-for-xxlarge, .show-for-xxlarge-down {
     display: inherit !important; }
-
   .show-for-small-only, .hide-for-small-up, .show-for-small, .show-for-small-down, .show-for-medium-only, .hide-for-medium-up, .show-for-medium, .show-for-medium-down, .hide-for-large-only, .hide-for-large-up, .hide-for-large, .hide-for-large-down, .show-for-xlarge-only, .show-for-xlarge-up, .show-for-xlarge, .hide-for-xlarge-down, .show-for-xxlarge-only, .show-for-xxlarge-up, .show-for-xxlarge, .hide-for-xxlarge-down {
     display: none !important; }
-
   .hidden-for-small-only, .visible-for-small-up, .hidden-for-small, .hidden-for-small-down, .hidden-for-medium-only, .visible-for-medium-up, .hidden-for-medium, .hidden-for-medium-down, .visible-for-large-only, .visible-for-large-up, .visible-for-large, .visible-for-large-down, .hidden-for-xlarge-only, .hidden-for-xlarge-up, .hidden-for-xlarge, .visible-for-xlarge-down, .hidden-for-xxlarge-only, .hidden-for-xxlarge-up, .hidden-for-xxlarge, .visible-for-xxlarge-down {
     position: static !important;
     height: auto;
     width: auto;
     overflow: visible;
     clip: auto; }
-
   .visible-for-small-only, .hidden-for-small-up, .visible-for-small, .visible-for-small-down, .visible-for-medium-only, .hidden-for-medium-up, .visible-for-medium, .visible-for-medium-down, .hidden-for-large-only, .hidden-for-large-up, .hidden-for-large, .hidden-for-large-down, .visible-for-xlarge-only, .visible-for-xlarge-up, .visible-for-xlarge, .hidden-for-xlarge-down, .visible-for-xxlarge-only, .visible-for-xxlarge-up, .visible-for-xxlarge, .hidden-for-xxlarge-down {
     clip: rect(1px, 1px, 1px, 1px);
     height: 1px;
     overflow: hidden;
     position: absolute !important;
     width: 1px; }
-
   table.hide-for-small-only, table.show-for-small-up, table.hide-for-small, table.hide-for-small-down, table.hide-for-medium-only, table.show-for-medium-up, table.hide-for-medium, table.hide-for-medium-down, table.show-for-large-only, table.show-for-large-up, table.show-for-large, table.show-for-large-down, table.hide-for-xlarge-only, table.hide-for-xlarge-up, table.hide-for-xlarge, table.show-for-xlarge-down, table.hide-for-xxlarge-only, table.hide-for-xxlarge-up, table.hide-for-xxlarge, table.show-for-xxlarge-down {
     display: table !important; }
-
   thead.hide-for-small-only, thead.show-for-small-up, thead.hide-for-small, thead.hide-for-small-down, thead.hide-for-medium-only, thead.show-for-medium-up, thead.hide-for-medium, thead.hide-for-medium-down, thead.show-for-large-only, thead.show-for-large-up, thead.show-for-large, thead.show-for-large-down, thead.hide-for-xlarge-only, thead.hide-for-xlarge-up, thead.hide-for-xlarge, thead.show-for-xlarge-down, thead.hide-for-xxlarge-only, thead.hide-for-xxlarge-up, thead.hide-for-xxlarge, thead.show-for-xxlarge-down {
     display: table-header-group !important; }
-
   tbody.hide-for-small-only, tbody.show-for-small-up, tbody.hide-for-small, tbody.hide-for-small-down, tbody.hide-for-medium-only, tbody.show-for-medium-up, tbody.hide-for-medium, tbody.hide-for-medium-down, tbody.show-for-large-only, tbody.show-for-large-up, tbody.show-for-large, tbody.show-for-large-down, tbody.hide-for-xlarge-only, tbody.hide-for-xlarge-up, tbody.hide-for-xlarge, tbody.show-for-xlarge-down, tbody.hide-for-xxlarge-only, tbody.hide-for-xxlarge-up, tbody.hide-for-xxlarge, tbody.show-for-xxlarge-down {
     display: table-row-group !important; }
-
   tr.hide-for-small-only, tr.show-for-small-up, tr.hide-for-small, tr.hide-for-small-down, tr.hide-for-medium-only, tr.show-for-medium-up, tr.hide-for-medium, tr.hide-for-medium-down, tr.show-for-large-only, tr.show-for-large-up, tr.show-for-large, tr.show-for-large-down, tr.hide-for-xlarge-only, tr.hide-for-xlarge-up, tr.hide-for-xlarge, tr.show-for-xlarge-down, tr.hide-for-xxlarge-only, tr.hide-for-xxlarge-up, tr.hide-for-xxlarge, tr.show-for-xxlarge-down {
     display: table-row; }
-
   th.hide-for-small-only, td.hide-for-small-only, .backgrid th.hide-for-small-only, th.show-for-small-up, td.show-for-small-up, .backgrid th.show-for-small-up, th.hide-for-small, td.hide-for-small, .backgrid th.hide-for-small, th.hide-for-small-down, td.hide-for-small-down, .backgrid th.hide-for-small-down, th.hide-for-medium-only, td.hide-for-medium-only, .backgrid th.hide-for-medium-only, th.show-for-medium-up, td.show-for-medium-up, .backgrid th.show-for-medium-up, th.hide-for-medium, td.hide-for-medium, .backgrid th.hide-for-medium, th.hide-for-medium-down, td.hide-for-medium-down, .backgrid th.hide-for-medium-down, th.show-for-large-only, td.show-for-large-only, .backgrid th.show-for-large-only, th.show-for-large-up, td.show-for-large-up, .backgrid th.show-for-large-up, th.show-for-large, td.show-for-large, .backgrid th.show-for-large, th.show-for-large-down, td.show-for-large-down, .backgrid th.show-for-large-down, th.hide-for-xlarge-only, td.hide-for-xlarge-only, .backgrid th.hide-for-xlarge-only, th.hide-for-xlarge-up, td.hide-for-xlarge-up, .backgrid th.hide-for-xlarge-up, th.hide-for-xlarge, td.hide-for-xlarge, .backgrid th.hide-for-xlarge, th.show-for-xlarge-down, td.show-for-xlarge-down, .backgrid th.show-for-xlarge-down, th.hide-for-xxlarge-only, td.hide-for-xxlarge-only, .backgrid th.hide-for-xxlarge-only, th.hide-for-xxlarge-up, td.hide-for-xxlarge-up, .backgrid th.hide-for-xxlarge-up, th.hide-for-xxlarge, td.hide-for-xxlarge, .backgrid th.hide-for-xxlarge, th.show-for-xxlarge-down, td.show-for-xxlarge-down, .backgrid th.show-for-xxlarge-down {
     display: table-cell !important; } }
+
 /* xlarge displays */
 @media only screen and (min-width: 90.0625em) {
   .hide-for-small-only, .show-for-small-up, .hide-for-small, .hide-for-small-down, .hide-for-medium-only, .show-for-medium-up, .hide-for-medium, .hide-for-medium-down, .hide-for-large-only, .show-for-large-up, .hide-for-large, .hide-for-large-down, .show-for-xlarge-only, .show-for-xlarge-up, .show-for-xlarge, .show-for-xlarge-down, .hide-for-xxlarge-only, .hide-for-xxlarge-up, .hide-for-xxlarge, .show-for-xxlarge-down {
     display: inherit !important; }
-
   .show-for-small-only, .hide-for-small-up, .show-for-small, .show-for-small-down, .show-for-medium-only, .hide-for-medium-up, .show-for-medium, .show-for-medium-down, .show-for-large-only, .hide-for-large-up, .show-for-large, .show-for-large-down, .hide-for-xlarge-only, .hide-for-xlarge-up, .hide-for-xlarge, .hide-for-xlarge-down, .show-for-xxlarge-only, .show-for-xxlarge-up, .show-for-xxlarge, .hide-for-xxlarge-down {
     display: none !important; }
-
   .hidden-for-small-only, .visible-for-small-up, .hidden-for-small, .hidden-for-small-down, .hidden-for-medium-only, .visible-for-medium-up, .hidden-for-medium, .hidden-for-medium-down, .hidden-for-large-only, .visible-for-large-up, .hidden-for-large, .hidden-for-large-down, .visible-for-xlarge-only, .visible-for-xlarge-up, .visible-for-xlarge, .visible-for-xlarge-down, .hidden-for-xxlarge-only, .hidden-for-xxlarge-up, .hidden-for-xxlarge, .visible-for-xxlarge-down {
     position: static !important;
     height: auto;
     width: auto;
     overflow: visible;
     clip: auto; }
-
   .visible-for-small-only, .hidden-for-small-up, .visible-for-small, .visible-for-small-down, .visible-for-medium-only, .hidden-for-medium-up, .visible-for-medium, .visible-for-medium-down, .visible-for-large-only, .hidden-for-large-up, .visible-for-large, .visible-for-large-down, .hidden-for-xlarge-only, .hidden-for-xlarge-up, .hidden-for-xlarge, .hidden-for-xlarge-down, .visible-for-xxlarge-only, .visible-for-xxlarge-up, .visible-for-xxlarge, .hidden-for-xxlarge-down {
     clip: rect(1px, 1px, 1px, 1px);
     height: 1px;
     overflow: hidden;
     position: absolute !important;
     width: 1px; }
-
   table.hide-for-small-only, table.show-for-small-up, table.hide-for-small, table.hide-for-small-down, table.hide-for-medium-only, table.show-for-medium-up, table.hide-for-medium, table.hide-for-medium-down, table.hide-for-large-only, table.show-for-large-up, table.hide-for-large, table.hide-for-large-down, table.show-for-xlarge-only, table.show-for-xlarge-up, table.show-for-xlarge, table.show-for-xlarge-down, table.hide-for-xxlarge-only, table.hide-for-xxlarge-up, table.hide-for-xxlarge, table.show-for-xxlarge-down {
     display: table !important; }
-
   thead.hide-for-small-only, thead.show-for-small-up, thead.hide-for-small, thead.hide-for-small-down, thead.hide-for-medium-only, thead.show-for-medium-up, thead.hide-for-medium, thead.hide-for-medium-down, thead.hide-for-large-only, thead.show-for-large-up, thead.hide-for-large, thead.hide-for-large-down, thead.show-for-xlarge-only, thead.show-for-xlarge-up, thead.show-for-xlarge, thead.show-for-xlarge-down, thead.hide-for-xxlarge-only, thead.hide-for-xxlarge-up, thead.hide-for-xxlarge, thead.show-for-xxlarge-down {
     display: table-header-group !important; }
-
   tbody.hide-for-small-only, tbody.show-for-small-up, tbody.hide-for-small, tbody.hide-for-small-down, tbody.hide-for-medium-only, tbody.show-for-medium-up, tbody.hide-for-medium, tbody.hide-for-medium-down, tbody.hide-for-large-only, tbody.show-for-large-up, tbody.hide-for-large, tbody.hide-for-large-down, tbody.show-for-xlarge-only, tbody.show-for-xlarge-up, tbody.show-for-xlarge, tbody.show-for-xlarge-down, tbody.hide-for-xxlarge-only, tbody.hide-for-xxlarge-up, tbody.hide-for-xxlarge, tbody.show-for-xxlarge-down {
     display: table-row-group !important; }
-
   tr.hide-for-small-only, tr.show-for-small-up, tr.hide-for-small, tr.hide-for-small-down, tr.hide-for-medium-only, tr.show-for-medium-up, tr.hide-for-medium, tr.hide-for-medium-down, tr.hide-for-large-only, tr.show-for-large-up, tr.hide-for-large, tr.hide-for-large-down, tr.show-for-xlarge-only, tr.show-for-xlarge-up, tr.show-for-xlarge, tr.show-for-xlarge-down, tr.hide-for-xxlarge-only, tr.hide-for-xxlarge-up, tr.hide-for-xxlarge, tr.show-for-xxlarge-down {
     display: table-row; }
-
   th.hide-for-small-only, td.hide-for-small-only, .backgrid th.hide-for-small-only, th.show-for-small-up, td.show-for-small-up, .backgrid th.show-for-small-up, th.hide-for-small, td.hide-for-small, .backgrid th.hide-for-small, th.hide-for-small-down, td.hide-for-small-down, .backgrid th.hide-for-small-down, th.hide-for-medium-only, td.hide-for-medium-only, .backgrid th.hide-for-medium-only, th.show-for-medium-up, td.show-for-medium-up, .backgrid th.show-for-medium-up, th.hide-for-medium, td.hide-for-medium, .backgrid th.hide-for-medium, th.hide-for-medium-down, td.hide-for-medium-down, .backgrid th.hide-for-medium-down, th.hide-for-large-only, td.hide-for-large-only, .backgrid th.hide-for-large-only, th.show-for-large-up, td.show-for-large-up, .backgrid th.show-for-large-up, th.hide-for-large, td.hide-for-large, .backgrid th.hide-for-large, th.hide-for-large-down, td.hide-for-large-down, .backgrid th.hide-for-large-down, th.show-for-xlarge-only, td.show-for-xlarge-only, .backgrid th.show-for-xlarge-only, th.show-for-xlarge-up, td.show-for-xlarge-up, .backgrid th.show-for-xlarge-up, th.show-for-xlarge, td.show-for-xlarge, .backgrid th.show-for-xlarge, th.show-for-xlarge-down, td.show-for-xlarge-down, .backgrid th.show-for-xlarge-down, th.hide-for-xxlarge-only, td.hide-for-xxlarge-only, .backgrid th.hide-for-xxlarge-only, th.hide-for-xxlarge-up, td.hide-for-xxlarge-up, .backgrid th.hide-for-xxlarge-up, th.hide-for-xxlarge, td.hide-for-xxlarge, .backgrid th.hide-for-xxlarge, th.show-for-xxlarge-down, td.show-for-xxlarge-down, .backgrid th.show-for-xxlarge-down {
     display: table-cell !important; } }
+
 /* xxlarge displays */
 @media only screen and (min-width: 120.0625em) {
   .hide-for-small-only, .show-for-small-up, .hide-for-small, .hide-for-small-down, .hide-for-medium-only, .show-for-medium-up, .hide-for-medium, .hide-for-medium-down, .hide-for-large-only, .show-for-large-up, .hide-for-large, .hide-for-large-down, .hide-for-xlarge-only, .show-for-xlarge-up, .hide-for-xlarge, .hide-for-xlarge-down, .show-for-xxlarge-only, .show-for-xxlarge-up, .show-for-xxlarge, .show-for-xxlarge-down {
     display: inherit !important; }
-
   .show-for-small-only, .hide-for-small-up, .show-for-small, .show-for-small-down, .show-for-medium-only, .hide-for-medium-up, .show-for-medium, .show-for-medium-down, .show-for-large-only, .hide-for-large-up, .show-for-large, .show-for-large-down, .show-for-xlarge-only, .hide-for-xlarge-up, .show-for-xlarge, .show-for-xlarge-down, .hide-for-xxlarge-only, .hide-for-xxlarge-up, .hide-for-xxlarge, .hide-for-xxlarge-down {
     display: none !important; }
-
   .hidden-for-small-only, .visible-for-small-up, .hidden-for-small, .hidden-for-small-down, .hidden-for-medium-only, .visible-for-medium-up, .hidden-for-medium, .hidden-for-medium-down, .hidden-for-large-only, .visible-for-large-up, .hidden-for-large, .hidden-for-large-down, .hidden-for-xlarge-only, .visible-for-xlarge-up, .hidden-for-xlarge, .hidden-for-xlarge-down, .visible-for-xxlarge-only, .visible-for-xxlarge-up, .visible-for-xxlarge, .visible-for-xxlarge-down {
     position: static !important;
     height: auto;
     width: auto;
     overflow: visible;
     clip: auto; }
-
   .visible-for-small-only, .hidden-for-small-up, .visible-for-small, .visible-for-small-down, .visible-for-medium-only, .hidden-for-medium-up, .visible-for-medium, .visible-for-medium-down, .visible-for-large-only, .hidden-for-large-up, .visible-for-large, .visible-for-large-down, .visible-for-xlarge-only, .hidden-for-xlarge-up, .visible-for-xlarge, .visible-for-xlarge-down, .hidden-for-xxlarge-only, .hidden-for-xxlarge-up, .hidden-for-xxlarge, .hidden-for-xxlarge-down {
     clip: rect(1px, 1px, 1px, 1px);
     height: 1px;
     overflow: hidden;
     position: absolute !important;
     width: 1px; }
-
   table.hide-for-small-only, table.show-for-small-up, table.hide-for-small, table.hide-for-small-down, table.hide-for-medium-only, table.show-for-medium-up, table.hide-for-medium, table.hide-for-medium-down, table.hide-for-large-only, table.show-for-large-up, table.hide-for-large, table.hide-for-large-down, table.hide-for-xlarge-only, table.show-for-xlarge-up, table.hide-for-xlarge, table.hide-for-xlarge-down, table.show-for-xxlarge-only, table.show-for-xxlarge-up, table.show-for-xxlarge, table.show-for-xxlarge-down {
     display: table !important; }
-
   thead.hide-for-small-only, thead.show-for-small-up, thead.hide-for-small, thead.hide-for-small-down, thead.hide-for-medium-only, thead.show-for-medium-up, thead.hide-for-medium, thead.hide-for-medium-down, thead.hide-for-large-only, thead.show-for-large-up, thead.hide-for-large, thead.hide-for-large-down, thead.hide-for-xlarge-only, thead.show-for-xlarge-up, thead.hide-for-xlarge, thead.hide-for-xlarge-down, thead.show-for-xxlarge-only, thead.show-for-xxlarge-up, thead.show-for-xxlarge, thead.show-for-xxlarge-down {
     display: table-header-group !important; }
-
   tbody.hide-for-small-only, tbody.show-for-small-up, tbody.hide-for-small, tbody.hide-for-small-down, tbody.hide-for-medium-only, tbody.show-for-medium-up, tbody.hide-for-medium, tbody.hide-for-medium-down, tbody.hide-for-large-only, tbody.show-for-large-up, tbody.hide-for-large, tbody.hide-for-large-down, tbody.hide-for-xlarge-only, tbody.show-for-xlarge-up, tbody.hide-for-xlarge, tbody.hide-for-xlarge-down, tbody.show-for-xxlarge-only, tbody.show-for-xxlarge-up, tbody.show-for-xxlarge, tbody.show-for-xxlarge-down {
     display: table-row-group !important; }
-
   tr.hide-for-small-only, tr.show-for-small-up, tr.hide-for-small, tr.hide-for-small-down, tr.hide-for-medium-only, tr.show-for-medium-up, tr.hide-for-medium, tr.hide-for-medium-down, tr.hide-for-large-only, tr.show-for-large-up, tr.hide-for-large, tr.hide-for-large-down, tr.hide-for-xlarge-only, tr.show-for-xlarge-up, tr.hide-for-xlarge, tr.hide-for-xlarge-down, tr.show-for-xxlarge-only, tr.show-for-xxlarge-up, tr.show-for-xxlarge, tr.show-for-xxlarge-down {
     display: table-row; }
-
   th.hide-for-small-only, td.hide-for-small-only, .backgrid th.hide-for-small-only, th.show-for-small-up, td.show-for-small-up, .backgrid th.show-for-small-up, th.hide-for-small, td.hide-for-small, .backgrid th.hide-for-small, th.hide-for-small-down, td.hide-for-small-down, .backgrid th.hide-for-small-down, th.hide-for-medium-only, td.hide-for-medium-only, .backgrid th.hide-for-medium-only, th.show-for-medium-up, td.show-for-medium-up, .backgrid th.show-for-medium-up, th.hide-for-medium, td.hide-for-medium, .backgrid th.hide-for-medium, th.hide-for-medium-down, td.hide-for-medium-down, .backgrid th.hide-for-medium-down, th.hide-for-large-only, td.hide-for-large-only, .backgrid th.hide-for-large-only, th.show-for-large-up, td.show-for-large-up, .backgrid th.show-for-large-up, th.hide-for-large, td.hide-for-large, .backgrid th.hide-for-large, th.hide-for-large-down, td.hide-for-large-down, .backgrid th.hide-for-large-down, th.hide-for-xlarge-only, td.hide-for-xlarge-only, .backgrid th.hide-for-xlarge-only, th.show-for-xlarge-up, td.show-for-xlarge-up, .backgrid th.show-for-xlarge-up, th.hide-for-xlarge, td.hide-for-xlarge, .backgrid th.hide-for-xlarge, th.hide-for-xlarge-down, td.hide-for-xlarge-down, .backgrid th.hide-for-xlarge-down, th.show-for-xxlarge-only, td.show-for-xxlarge-only, .backgrid th.show-for-xxlarge-only, th.show-for-xxlarge-up, td.show-for-xxlarge-up, .backgrid th.show-for-xxlarge-up, th.show-for-xxlarge, td.show-for-xxlarge, .backgrid th.show-for-xxlarge, th.show-for-xxlarge-down, td.show-for-xxlarge-down, .backgrid th.show-for-xxlarge-down {
     display: table-cell !important; } }
+
 /* Orientation targeting */
 .show-for-landscape,
 .hide-for-portrait {
@@ -6440,54 +6266,44 @@ th.show-for-portrait {
   .show-for-landscape,
   .hide-for-portrait {
     display: inherit !important; }
-
   .hide-for-landscape,
   .show-for-portrait {
     display: none !important; }
-
   /* Specific visibility for tables */
   table.show-for-landscape, table.hide-for-portrait {
     display: table !important; }
-
   thead.show-for-landscape, thead.hide-for-portrait {
     display: table-header-group !important; }
-
   tbody.show-for-landscape, tbody.hide-for-portrait {
     display: table-row-group !important; }
-
   tr.show-for-landscape, tr.hide-for-portrait {
     display: table-row !important; }
-
   td.show-for-landscape, .backgrid th.show-for-landscape, td.hide-for-portrait, .backgrid th.hide-for-portrait,
   th.show-for-landscape,
   th.hide-for-portrait {
     display: table-cell !important; } }
+
 @media only screen and (orientation: portrait) {
   .show-for-portrait,
   .hide-for-landscape {
     display: inherit !important; }
-
   .hide-for-portrait,
   .show-for-landscape {
     display: none !important; }
-
   /* Specific visibility for tables */
   table.show-for-portrait, table.hide-for-landscape {
     display: table !important; }
-
   thead.show-for-portrait, thead.hide-for-landscape {
     display: table-header-group !important; }
-
   tbody.show-for-portrait, tbody.hide-for-landscape {
     display: table-row-group !important; }
-
   tr.show-for-portrait, tr.hide-for-landscape {
     display: table-row !important; }
-
   td.show-for-portrait, .backgrid th.show-for-portrait, td.hide-for-landscape, .backgrid th.hide-for-landscape,
   th.show-for-portrait,
   th.hide-for-landscape {
     display: table-cell !important; } }
+
 /* Touch-enabled device targeting */
 .show-for-touch {
   display: none !important; }
@@ -6568,28 +6384,22 @@ th.hide-for-touch {
   .print-only,
   .show-for-print {
     display: block !important; }
-
   .hide-on-print,
   .hide-for-print {
     display: none !important; }
-
   table.show-for-print {
     display: table !important; }
-
   thead.show-for-print {
     display: table-header-group !important; }
-
   tbody.show-for-print {
     display: table-row-group !important; }
-
   tr.show-for-print {
     display: table-row !important; }
-
   td.show-for-print, .backgrid th.show-for-print {
     display: table-cell !important; }
-
   th.show-for-print {
     display: table-cell !important; } }
+
 /* graph */
 .rickshaw_graph {
   position: relative; }
@@ -6849,6 +6659,7 @@ th.hide-for-touch {
 
 .rickshaw_graph .x_tick.plain {
   bottom: 0em; }
+
 .rickshaw_graph .title {
   opacity: 1; }
 
@@ -7165,8 +6976,7 @@ th.hide-for-touch {
     .backgrid td.renderable, .backgrid th.renderable {
       display: table-cell; }
   .backgrid td.error, .backgrid th.error,
-  .backgrid tbody tr:nth-child(odd) td.error,
-  .backgrid tbody tr:nth-child(odd) th.error {
+  .backgrid tbody tr:nth-child(odd) td.error, .backgrid tbody tr:nth-child(odd) th.error {
     background-color: rgba(255, 210, 77, 0.1);
     outline: 1px solid #ffd24d; }
   .backgrid th {
@@ -7530,6 +7340,7 @@ pre .tex .formula {
   src: url("foundation-icons.eot?#iefix") format("embedded-opentype"), url("foundation-icons.woff") format("woff"), url("foundation-icons.ttf") format("truetype"), url("foundation-icons.svg#fontcustom") format("svg");
   font-weight: normal;
   font-style: normal; }
+
 .fi-address-book:before,
 .fi-alert:before,
 .fi-align-center:before,
@@ -8840,6 +8651,7 @@ pre .tex .formula {
   width: 2.8125rem;
   height: 2.8125rem;
   display: block; }
+
 .top-bar .menu-icon span::after {
   box-shadow: 0 0 0 1px #ffffff, 0 7px 0 1px #ffffff, 0 14px 0 1px #ffffff;
   content: "";
@@ -8864,6 +8676,7 @@ pre .tex .formula {
   padding-right: 5px; }
   .side-nav a.close:hover {
     opacity: 0.8; }
+
 .side-nav li a.dropdown {
   position: relative;
   padding-right: 3.0625rem; }
@@ -8882,6 +8695,7 @@ pre .tex .formula {
     margin-top: -0.15625rem; }
   .side-nav li a.dropdown::after {
     border-color: #FFFFFF transparent transparent transparent; }
+
 .side-nav li.active {
   background: none repeat scroll #474747; }
 
@@ -8907,6 +8721,7 @@ footer {
   min-height: 200px; }
   .panel.widget .content-widget title {
     color: #859145; }
+
 .panel .row.graph {
   padding-left: 3rem;
   padding-right: 1.5rem; }
@@ -8954,5 +8769,3 @@ footer {
 
 .breadcrumbs > *.current a:hover {
   text-decoration: underline; }
-
-/*# sourceMappingURL=powa-all.min.css.map */


### PR DESCRIPTION
As opposed to `grunt-contrib-sass`, `grunt-sass` doesn't require Ruby nor Sass to be installed on the system. It relies on `node-sass` which makes installation a bit easier.

Note: modifications on the built `.min.css` are due to precision in rounded values or formatting.